### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/teledart/fetch/webhook.dart
+++ b/lib/src/teledart/fetch/webhook.dart
@@ -94,7 +94,7 @@ class Webhook {
     }
     _server.listen((io.HttpRequest request) {
       if (request.method == 'POST' && request.uri.path == this.secretPath) {
-        request.transform(utf8.decoder).join().then((data) {
+        request.cast<List<int>>().transform(utf8.decoder).join().then((data) {
           emitUpdate(Update.fromJson(jsonDecode(data)));
           request.response
             ..write(jsonEncode({'ok': true}))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: teledart
 description: A Dart library interfacing with the latest Telegram Bot API.
-version: 0.0.31
+version: 0.0.31+1
 homepage: https://github.com/DinoLeung/TeleDart
 author: Dino Leung <dino@330z.net>
 


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900