### PR TITLE
WIP: api 4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+
+- Support API 4.3
+
 ## 0.0.32
 
 - Prepare for upcoming change to HttpRequest and HttpClientResponse

--- a/lib/src/telegram/model.dart
+++ b/lib/src/telegram/model.dart
@@ -34,6 +34,7 @@ part 'models/animation.dart';
 part 'models/voice.dart';
 part 'models/video_note.dart';
 part 'models/contact.dart';
+part 'models/login_url.dart';
 part 'models/location.dart';
 part 'models/venue.dart';
 part 'models/poll_option.dart';

--- a/lib/src/telegram/model.g.dart
+++ b/lib/src/telegram/model.g.dart
@@ -289,6 +289,10 @@ Message _$MessageFromJson(Map<String, dynamic> json) {
     passport_data: json['passport_data'] == null
         ? null
         : PassportData.fromJson(json['passport_data'] as Map<String, dynamic>),
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
   );
 }
 
@@ -347,6 +351,7 @@ Map<String, dynamic> _$MessageToJson(Message instance) {
   writeNotNull('successful_payment', instance.successful_payment);
   writeNotNull('connected_website', instance.connected_website);
   writeNotNull('passport_data', instance.passport_data);
+  writeNotNull('reply_markup', instance.reply_markup);
   return val;
 }
 
@@ -901,6 +906,9 @@ InlineKeyboardButton _$InlineKeyboardButtonFromJson(Map<String, dynamic> json) {
   return InlineKeyboardButton(
     text: json['text'] as String,
     url: json['url'] as String,
+    login_url: json['login_url'] == null
+        ? null
+        : LoginUrl.fromJson(json['login_url'] as Map<String, dynamic>),
     callback_data: json['callback_data'] as String,
     switch_inline_query: json['switch_inline_query'] as String,
     switch_inline_query_current_chat:
@@ -924,6 +932,7 @@ Map<String, dynamic> _$InlineKeyboardButtonToJson(
 
   writeNotNull('text', instance.text);
   writeNotNull('url', instance.url);
+  writeNotNull('login_url', instance.login_url);
   writeNotNull('callback_data', instance.callback_data);
   writeNotNull('switch_inline_query', instance.switch_inline_query);
   writeNotNull('switch_inline_query_current_chat',

--- a/lib/src/telegram/model.g.dart
+++ b/lib/src/telegram/model.g.dart
@@ -8,42 +8,42 @@ part of 'model.dart';
 
 Update _$UpdateFromJson(Map<String, dynamic> json) {
   return Update(
-      update_id: json['update_id'] as int,
-      message: json['message'] == null
-          ? null
-          : Message.fromJson(json['message'] as Map<String, dynamic>),
-      edited_message: json['edited_message'] == null
-          ? null
-          : Message.fromJson(json['edited_message'] as Map<String, dynamic>),
-      channel_post: json['channel_post'] == null
-          ? null
-          : Message.fromJson(json['channel_post'] as Map<String, dynamic>),
-      edited_channel_post: json['edited_channel_post'] == null
-          ? null
-          : Message.fromJson(
-              json['edited_channel_post'] as Map<String, dynamic>),
-      inline_query: json['inline_query'] == null
-          ? null
-          : InlineQuery.fromJson(json['inline_query'] as Map<String, dynamic>),
-      chosen_inline_result: json['chosen_inline_result'] == null
-          ? null
-          : ChosenInlineResult.fromJson(
-              json['chosen_inline_result'] as Map<String, dynamic>),
-      callback_query: json['callback_query'] == null
-          ? null
-          : CallbackQuery.fromJson(
-              json['callback_query'] as Map<String, dynamic>),
-      shipping_query: json['shipping_query'] == null
-          ? null
-          : ShippingQuery.fromJson(
-              json['shipping_query'] as Map<String, dynamic>),
-      pre_checkout_query: json['pre_checkout_query'] == null
-          ? null
-          : PreCheckoutQuery.fromJson(
-              json['pre_checkout_query'] as Map<String, dynamic>),
-      poll: json['poll'] == null
-          ? null
-          : Poll.fromJson(json['poll'] as Map<String, dynamic>));
+    update_id: json['update_id'] as int,
+    message: json['message'] == null
+        ? null
+        : Message.fromJson(json['message'] as Map<String, dynamic>),
+    edited_message: json['edited_message'] == null
+        ? null
+        : Message.fromJson(json['edited_message'] as Map<String, dynamic>),
+    channel_post: json['channel_post'] == null
+        ? null
+        : Message.fromJson(json['channel_post'] as Map<String, dynamic>),
+    edited_channel_post: json['edited_channel_post'] == null
+        ? null
+        : Message.fromJson(json['edited_channel_post'] as Map<String, dynamic>),
+    inline_query: json['inline_query'] == null
+        ? null
+        : InlineQuery.fromJson(json['inline_query'] as Map<String, dynamic>),
+    chosen_inline_result: json['chosen_inline_result'] == null
+        ? null
+        : ChosenInlineResult.fromJson(
+            json['chosen_inline_result'] as Map<String, dynamic>),
+    callback_query: json['callback_query'] == null
+        ? null
+        : CallbackQuery.fromJson(
+            json['callback_query'] as Map<String, dynamic>),
+    shipping_query: json['shipping_query'] == null
+        ? null
+        : ShippingQuery.fromJson(
+            json['shipping_query'] as Map<String, dynamic>),
+    pre_checkout_query: json['pre_checkout_query'] == null
+        ? null
+        : PreCheckoutQuery.fromJson(
+            json['pre_checkout_query'] as Map<String, dynamic>),
+    poll: json['poll'] == null
+        ? null
+        : Poll.fromJson(json['poll'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$UpdateToJson(Update instance) {
@@ -71,14 +71,15 @@ Map<String, dynamic> _$UpdateToJson(Update instance) {
 
 WebhookInfo _$WebhookInfoFromJson(Map<String, dynamic> json) {
   return WebhookInfo(
-      url: json['url'] as String,
-      has_custom_certificate: json['has_custom_certificate'] as bool,
-      pending_update_count: json['pending_update_count'] as int,
-      last_error_date: json['last_error_date'] as int,
-      last_error_message: json['last_error_message'] as String,
-      max_connections: json['max_connections'] as int,
-      allowed_updates:
-          (json['allowed_updates'] as List)?.map((e) => e as String)?.toList());
+    url: json['url'] as String,
+    has_custom_certificate: json['has_custom_certificate'] as bool,
+    pending_update_count: json['pending_update_count'] as int,
+    last_error_date: json['last_error_date'] as int,
+    last_error_message: json['last_error_message'] as String,
+    max_connections: json['max_connections'] as int,
+    allowed_updates:
+        (json['allowed_updates'] as List)?.map((e) => e as String)?.toList(),
+  );
 }
 
 Map<String, dynamic> _$WebhookInfoToJson(WebhookInfo instance) {
@@ -102,12 +103,13 @@ Map<String, dynamic> _$WebhookInfoToJson(WebhookInfo instance) {
 
 User _$UserFromJson(Map<String, dynamic> json) {
   return User(
-      id: json['id'] as int,
-      is_bot: json['is_bot'] as bool,
-      first_name: json['first_name'] as String,
-      last_name: json['last_name'] as String,
-      username: json['username'] as String,
-      language_code: json['language_code'] as String);
+    id: json['id'] as int,
+    is_bot: json['is_bot'] as bool,
+    first_name: json['first_name'] as String,
+    last_name: json['last_name'] as String,
+    username: json['username'] as String,
+    language_code: json['language_code'] as String,
+  );
 }
 
 Map<String, dynamic> _$UserToJson(User instance) {
@@ -130,24 +132,25 @@ Map<String, dynamic> _$UserToJson(User instance) {
 
 Chat _$ChatFromJson(Map<String, dynamic> json) {
   return Chat(
-      id: json['id'] as int,
-      type: json['type'] as String,
-      title: json['title'] as String,
-      username: json['username'] as String,
-      first_name: json['first_name'] as String,
-      last_name: json['last_name'] as String,
-      all_members_are_administrators:
-          json['all_members_are_administrators'] as bool,
-      photo: json['photo'] == null
-          ? null
-          : ChatPhoto.fromJson(json['photo'] as Map<String, dynamic>),
-      description: json['description'] as String,
-      invite_link: json['invite_link'] as String,
-      pinned_message: json['pinned_message'] == null
-          ? null
-          : Message.fromJson(json['pinned_message'] as Map<String, dynamic>),
-      sticker_set_name: json['sticker_set_name'] as String,
-      can_set_sticker_set: json['can_set_sticker_set'] as bool);
+    id: json['id'] as int,
+    type: json['type'] as String,
+    title: json['title'] as String,
+    username: json['username'] as String,
+    first_name: json['first_name'] as String,
+    last_name: json['last_name'] as String,
+    all_members_are_administrators:
+        json['all_members_are_administrators'] as bool,
+    photo: json['photo'] == null
+        ? null
+        : ChatPhoto.fromJson(json['photo'] as Map<String, dynamic>),
+    description: json['description'] as String,
+    invite_link: json['invite_link'] as String,
+    pinned_message: json['pinned_message'] == null
+        ? null
+        : Message.fromJson(json['pinned_message'] as Map<String, dynamic>),
+    sticker_set_name: json['sticker_set_name'] as String,
+    can_set_sticker_set: json['can_set_sticker_set'] as bool,
+  );
 }
 
 Map<String, dynamic> _$ChatToJson(Chat instance) {
@@ -178,114 +181,115 @@ Map<String, dynamic> _$ChatToJson(Chat instance) {
 
 Message _$MessageFromJson(Map<String, dynamic> json) {
   return Message(
-      message_id: json['message_id'] as int,
-      from: json['from'] == null
-          ? null
-          : User.fromJson(json['from'] as Map<String, dynamic>),
-      date: json['date'] as int,
-      chat: json['chat'] == null
-          ? null
-          : Chat.fromJson(json['chat'] as Map<String, dynamic>),
-      forward_from: json['forward_from'] == null
-          ? null
-          : User.fromJson(json['forward_from'] as Map<String, dynamic>),
-      forward_from_chat: json['forward_from_chat'] == null
-          ? null
-          : Chat.fromJson(json['forward_from_chat'] as Map<String, dynamic>),
-      forward_from_message_id: json['forward_from_message_id'] as int,
-      forward_signature: json['forward_signature'] as String,
-      forward_sender_name: json['forward_sender_name'] as String,
-      forward_date: json['forward_date'] as int,
-      reply_to_message: json['reply_to_message'] == null
-          ? null
-          : Message.fromJson(json['reply_to_message'] as Map<String, dynamic>),
-      edit_date: json['edit_date'] as int,
-      media_group_id: json['media_group_id'] as String,
-      author_signature: json['author_signature'] as String,
-      text: json['text'] as String,
-      entities: (json['entities'] as List)
-          ?.map((e) => e == null
-              ? null
-              : MessageEntity.fromJson(e as Map<String, dynamic>))
-          ?.toList(),
-      caption_entities: (json['caption_entities'] as List)
-          ?.map((e) => e == null
-              ? null
-              : MessageEntity.fromJson(e as Map<String, dynamic>))
-          ?.toList(),
-      audio: json['audio'] == null
-          ? null
-          : Audio.fromJson(json['audio'] as Map<String, dynamic>),
-      document: json['document'] == null
-          ? null
-          : Document.fromJson(json['document'] as Map<String, dynamic>),
-      animation: json['animation'] == null
-          ? null
-          : Animation.fromJson(json['animation'] as Map<String, dynamic>),
-      game: json['game'] == null
-          ? null
-          : Game.fromJson(json['game'] as Map<String, dynamic>),
-      photo: (json['photo'] as List)
-          ?.map((e) =>
-              e == null ? null : PhotoSize.fromJson(e as Map<String, dynamic>))
-          ?.toList(),
-      sticker: json['sticker'] == null
-          ? null
-          : Sticker.fromJson(json['sticker'] as Map<String, dynamic>),
-      video: json['video'] == null
-          ? null
-          : Video.fromJson(json['video'] as Map<String, dynamic>),
-      voice: json['voice'] == null
-          ? null
-          : Voice.fromJson(json['voice'] as Map<String, dynamic>),
-      video_note: json['video_note'] == null
-          ? null
-          : VideoNote.fromJson(json['video_note'] as Map<String, dynamic>),
-      caption: json['caption'] as String,
-      contact: json['contact'] == null
-          ? null
-          : Contact.fromJson(json['contact'] as Map<String, dynamic>),
-      location: json['location'] == null
-          ? null
-          : Location.fromJson(json['location'] as Map<String, dynamic>),
-      venue: json['venue'] == null
-          ? null
-          : Venue.fromJson(json['venue'] as Map<String, dynamic>),
-      poll: json['poll'] == null
-          ? null
-          : Poll.fromJson(json['poll'] as Map<String, dynamic>),
-      new_chat_members: (json['new_chat_members'] as List)
-          ?.map((e) =>
-              e == null ? null : User.fromJson(e as Map<String, dynamic>))
-          ?.toList(),
-      left_chat_member: json['left_chat_member'] == null
-          ? null
-          : User.fromJson(json['left_chat_member'] as Map<String, dynamic>),
-      new_chat_title: json['new_chat_title'] as String,
-      new_chat_photo: (json['new_chat_photo'] as List)
-          ?.map((e) =>
-              e == null ? null : PhotoSize.fromJson(e as Map<String, dynamic>))
-          ?.toList(),
-      delete_chat_photo: json['delete_chat_photo'] as bool,
-      group_chat_created: json['group_chat_created'] as bool,
-      supergroup_chat_created: json['supergroup_chat_created'] as bool,
-      channel_chat_created: json['channel_chat_created'] as bool,
-      migrate_to_chat_id: json['migrate_to_chat_id'] as int,
-      migrate_from_chat_id: json['migrate_from_chat_id'] as int,
-      pinned_message: json['pinned_message'] == null
-          ? null
-          : Message.fromJson(json['pinned_message'] as Map<String, dynamic>),
-      invoice: json['invoice'] == null
-          ? null
-          : Invoice.fromJson(json['invoice'] as Map<String, dynamic>),
-      successful_payment: json['successful_payment'] == null
-          ? null
-          : SuccessfulPayment.fromJson(
-              json['successful_payment'] as Map<String, dynamic>),
-      connected_website: json['connected_website'] as String,
-      passport_data: json['passport_data'] == null
-          ? null
-          : PassportData.fromJson(json['passport_data'] as Map<String, dynamic>));
+    message_id: json['message_id'] as int,
+    from: json['from'] == null
+        ? null
+        : User.fromJson(json['from'] as Map<String, dynamic>),
+    date: json['date'] as int,
+    chat: json['chat'] == null
+        ? null
+        : Chat.fromJson(json['chat'] as Map<String, dynamic>),
+    forward_from: json['forward_from'] == null
+        ? null
+        : User.fromJson(json['forward_from'] as Map<String, dynamic>),
+    forward_from_chat: json['forward_from_chat'] == null
+        ? null
+        : Chat.fromJson(json['forward_from_chat'] as Map<String, dynamic>),
+    forward_from_message_id: json['forward_from_message_id'] as int,
+    forward_signature: json['forward_signature'] as String,
+    forward_sender_name: json['forward_sender_name'] as String,
+    forward_date: json['forward_date'] as int,
+    reply_to_message: json['reply_to_message'] == null
+        ? null
+        : Message.fromJson(json['reply_to_message'] as Map<String, dynamic>),
+    edit_date: json['edit_date'] as int,
+    media_group_id: json['media_group_id'] as String,
+    author_signature: json['author_signature'] as String,
+    text: json['text'] as String,
+    entities: (json['entities'] as List)
+        ?.map((e) => e == null
+            ? null
+            : MessageEntity.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    caption_entities: (json['caption_entities'] as List)
+        ?.map((e) => e == null
+            ? null
+            : MessageEntity.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    audio: json['audio'] == null
+        ? null
+        : Audio.fromJson(json['audio'] as Map<String, dynamic>),
+    document: json['document'] == null
+        ? null
+        : Document.fromJson(json['document'] as Map<String, dynamic>),
+    animation: json['animation'] == null
+        ? null
+        : Animation.fromJson(json['animation'] as Map<String, dynamic>),
+    game: json['game'] == null
+        ? null
+        : Game.fromJson(json['game'] as Map<String, dynamic>),
+    photo: (json['photo'] as List)
+        ?.map((e) =>
+            e == null ? null : PhotoSize.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    sticker: json['sticker'] == null
+        ? null
+        : Sticker.fromJson(json['sticker'] as Map<String, dynamic>),
+    video: json['video'] == null
+        ? null
+        : Video.fromJson(json['video'] as Map<String, dynamic>),
+    voice: json['voice'] == null
+        ? null
+        : Voice.fromJson(json['voice'] as Map<String, dynamic>),
+    video_note: json['video_note'] == null
+        ? null
+        : VideoNote.fromJson(json['video_note'] as Map<String, dynamic>),
+    caption: json['caption'] as String,
+    contact: json['contact'] == null
+        ? null
+        : Contact.fromJson(json['contact'] as Map<String, dynamic>),
+    location: json['location'] == null
+        ? null
+        : Location.fromJson(json['location'] as Map<String, dynamic>),
+    venue: json['venue'] == null
+        ? null
+        : Venue.fromJson(json['venue'] as Map<String, dynamic>),
+    poll: json['poll'] == null
+        ? null
+        : Poll.fromJson(json['poll'] as Map<String, dynamic>),
+    new_chat_members: (json['new_chat_members'] as List)
+        ?.map(
+            (e) => e == null ? null : User.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    left_chat_member: json['left_chat_member'] == null
+        ? null
+        : User.fromJson(json['left_chat_member'] as Map<String, dynamic>),
+    new_chat_title: json['new_chat_title'] as String,
+    new_chat_photo: (json['new_chat_photo'] as List)
+        ?.map((e) =>
+            e == null ? null : PhotoSize.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    delete_chat_photo: json['delete_chat_photo'] as bool,
+    group_chat_created: json['group_chat_created'] as bool,
+    supergroup_chat_created: json['supergroup_chat_created'] as bool,
+    channel_chat_created: json['channel_chat_created'] as bool,
+    migrate_to_chat_id: json['migrate_to_chat_id'] as int,
+    migrate_from_chat_id: json['migrate_from_chat_id'] as int,
+    pinned_message: json['pinned_message'] == null
+        ? null
+        : Message.fromJson(json['pinned_message'] as Map<String, dynamic>),
+    invoice: json['invoice'] == null
+        ? null
+        : Invoice.fromJson(json['invoice'] as Map<String, dynamic>),
+    successful_payment: json['successful_payment'] == null
+        ? null
+        : SuccessfulPayment.fromJson(
+            json['successful_payment'] as Map<String, dynamic>),
+    connected_website: json['connected_website'] as String,
+    passport_data: json['passport_data'] == null
+        ? null
+        : PassportData.fromJson(json['passport_data'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$MessageToJson(Message instance) {
@@ -348,13 +352,14 @@ Map<String, dynamic> _$MessageToJson(Message instance) {
 
 MessageEntity _$MessageEntityFromJson(Map<String, dynamic> json) {
   return MessageEntity(
-      type: json['type'] as String,
-      offset: json['offset'] as int,
-      length: json['length'] as int,
-      url: json['url'] as String,
-      user: json['user'] == null
-          ? null
-          : User.fromJson(json['user'] as Map<String, dynamic>));
+    type: json['type'] as String,
+    offset: json['offset'] as int,
+    length: json['length'] as int,
+    url: json['url'] as String,
+    user: json['user'] == null
+        ? null
+        : User.fromJson(json['user'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$MessageEntityToJson(MessageEntity instance) {
@@ -376,10 +381,11 @@ Map<String, dynamic> _$MessageEntityToJson(MessageEntity instance) {
 
 PhotoSize _$PhotoSizeFromJson(Map<String, dynamic> json) {
   return PhotoSize(
-      file_id: json['file_id'] as String,
-      width: json['width'] as int,
-      height: json['height'] as int,
-      file_size: json['file_size'] as int);
+    file_id: json['file_id'] as String,
+    width: json['width'] as int,
+    height: json['height'] as int,
+    file_size: json['file_size'] as int,
+  );
 }
 
 Map<String, dynamic> _$PhotoSizeToJson(PhotoSize instance) {
@@ -400,15 +406,16 @@ Map<String, dynamic> _$PhotoSizeToJson(PhotoSize instance) {
 
 Audio _$AudioFromJson(Map<String, dynamic> json) {
   return Audio(
-      file_id: json['file_id'] as String,
-      duration: json['duration'] as int,
-      performer: json['performer'] as String,
-      title: json['title'] as String,
-      mime_type: json['mime_type'] as String,
-      file_size: json['file_size'] as int,
-      thumb: json['thumb'] == null
-          ? null
-          : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>));
+    file_id: json['file_id'] as String,
+    duration: json['duration'] as int,
+    performer: json['performer'] as String,
+    title: json['title'] as String,
+    mime_type: json['mime_type'] as String,
+    file_size: json['file_size'] as int,
+    thumb: json['thumb'] == null
+        ? null
+        : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$AudioToJson(Audio instance) {
@@ -432,13 +439,14 @@ Map<String, dynamic> _$AudioToJson(Audio instance) {
 
 Document _$DocumentFromJson(Map<String, dynamic> json) {
   return Document(
-      file_id: json['file_id'] as String,
-      thumb: json['thumb'] == null
-          ? null
-          : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>),
-      file_name: json['file_name'] as String,
-      mime_type: json['mime_type'] as String,
-      file_size: json['file_size'] as int);
+    file_id: json['file_id'] as String,
+    thumb: json['thumb'] == null
+        ? null
+        : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>),
+    file_name: json['file_name'] as String,
+    mime_type: json['mime_type'] as String,
+    file_size: json['file_size'] as int,
+  );
 }
 
 Map<String, dynamic> _$DocumentToJson(Document instance) {
@@ -460,15 +468,16 @@ Map<String, dynamic> _$DocumentToJson(Document instance) {
 
 Video _$VideoFromJson(Map<String, dynamic> json) {
   return Video(
-      file_id: json['file_id'] as String,
-      width: json['width'] as int,
-      height: json['height'] as int,
-      duration: json['duration'] as int,
-      thumb: json['thumb'] == null
-          ? null
-          : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>),
-      mime_type: json['mime_type'] as String,
-      file_size: json['file_size'] as int);
+    file_id: json['file_id'] as String,
+    width: json['width'] as int,
+    height: json['height'] as int,
+    duration: json['duration'] as int,
+    thumb: json['thumb'] == null
+        ? null
+        : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>),
+    mime_type: json['mime_type'] as String,
+    file_size: json['file_size'] as int,
+  );
 }
 
 Map<String, dynamic> _$VideoToJson(Video instance) {
@@ -492,16 +501,17 @@ Map<String, dynamic> _$VideoToJson(Video instance) {
 
 Animation _$AnimationFromJson(Map<String, dynamic> json) {
   return Animation(
-      file_id: json['file_id'] as String,
-      width: json['width'] as int,
-      height: json['height'] as int,
-      duration: json['duration'] as int,
-      thumb: json['thumb'] == null
-          ? null
-          : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>),
-      file_name: json['file_name'] as String,
-      mime_type: json['mime_type'] as String,
-      file_size: json['file_size'] as int);
+    file_id: json['file_id'] as String,
+    width: json['width'] as int,
+    height: json['height'] as int,
+    duration: json['duration'] as int,
+    thumb: json['thumb'] == null
+        ? null
+        : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>),
+    file_name: json['file_name'] as String,
+    mime_type: json['mime_type'] as String,
+    file_size: json['file_size'] as int,
+  );
 }
 
 Map<String, dynamic> _$AnimationToJson(Animation instance) {
@@ -526,10 +536,11 @@ Map<String, dynamic> _$AnimationToJson(Animation instance) {
 
 Voice _$VoiceFromJson(Map<String, dynamic> json) {
   return Voice(
-      file_id: json['file_id'] as String,
-      duration: json['duration'] as int,
-      mime_type: json['mime_type'] as String,
-      file_size: json['file_size'] as int);
+    file_id: json['file_id'] as String,
+    duration: json['duration'] as int,
+    mime_type: json['mime_type'] as String,
+    file_size: json['file_size'] as int,
+  );
 }
 
 Map<String, dynamic> _$VoiceToJson(Voice instance) {
@@ -550,13 +561,14 @@ Map<String, dynamic> _$VoiceToJson(Voice instance) {
 
 VideoNote _$VideoNoteFromJson(Map<String, dynamic> json) {
   return VideoNote(
-      file_id: json['file_id'] as String,
-      length: json['length'] as int,
-      duration: json['duration'] as int,
-      thumb: json['thumb'] == null
-          ? null
-          : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>),
-      file_size: json['file_size'] as int);
+    file_id: json['file_id'] as String,
+    length: json['length'] as int,
+    duration: json['duration'] as int,
+    thumb: json['thumb'] == null
+        ? null
+        : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>),
+    file_size: json['file_size'] as int,
+  );
 }
 
 Map<String, dynamic> _$VideoNoteToJson(VideoNote instance) {
@@ -578,11 +590,12 @@ Map<String, dynamic> _$VideoNoteToJson(VideoNote instance) {
 
 Contact _$ContactFromJson(Map<String, dynamic> json) {
   return Contact(
-      phone_number: json['phone_number'] as String,
-      first_name: json['first_name'] as String,
-      last_name: json['last_name'] as String,
-      user_id: json['user_id'] as int,
-      vcard: json['vcard'] as String);
+    phone_number: json['phone_number'] as String,
+    first_name: json['first_name'] as String,
+    last_name: json['last_name'] as String,
+    user_id: json['user_id'] as int,
+    vcard: json['vcard'] as String,
+  );
 }
 
 Map<String, dynamic> _$ContactToJson(Contact instance) {
@@ -602,10 +615,36 @@ Map<String, dynamic> _$ContactToJson(Contact instance) {
   return val;
 }
 
+LoginUrl _$LoginUrlFromJson(Map<String, dynamic> json) {
+  return LoginUrl(
+    json['url'],
+    forward_text: json['forward_text'] as String,
+    bot_username: json['bot_username'] as String,
+    request_write_access: json['request_write_access'] as bool,
+  );
+}
+
+Map<String, dynamic> _$LoginUrlToJson(LoginUrl instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('url', instance.url);
+  writeNotNull('forward_text', instance.forward_text);
+  writeNotNull('bot_username', instance.bot_username);
+  writeNotNull('request_write_access', instance.request_write_access);
+  return val;
+}
+
 Location _$LocationFromJson(Map<String, dynamic> json) {
   return Location(
-      longitude: (json['longitude'] as num)?.toDouble(),
-      latitude: (json['latitude'] as num)?.toDouble());
+    longitude: (json['longitude'] as num)?.toDouble(),
+    latitude: (json['latitude'] as num)?.toDouble(),
+  );
 }
 
 Map<String, dynamic> _$LocationToJson(Location instance) {
@@ -624,13 +663,14 @@ Map<String, dynamic> _$LocationToJson(Location instance) {
 
 Venue _$VenueFromJson(Map<String, dynamic> json) {
   return Venue(
-      location: json['location'] == null
-          ? null
-          : Location.fromJson(json['location'] as Map<String, dynamic>),
-      title: json['title'] as String,
-      address: json['address'] as String,
-      foursquare_id: json['foursquare_id'] as String,
-      foursquare_type: json['foursquare_type'] as String);
+    location: json['location'] == null
+        ? null
+        : Location.fromJson(json['location'] as Map<String, dynamic>),
+    title: json['title'] as String,
+    address: json['address'] as String,
+    foursquare_id: json['foursquare_id'] as String,
+    foursquare_type: json['foursquare_type'] as String,
+  );
 }
 
 Map<String, dynamic> _$VenueToJson(Venue instance) {
@@ -652,7 +692,9 @@ Map<String, dynamic> _$VenueToJson(Venue instance) {
 
 PollOption _$PollOptionFromJson(Map<String, dynamic> json) {
   return PollOption(
-      text: json['text'] as String, voter_count: json['voter_count'] as int);
+    text: json['text'] as String,
+    voter_count: json['voter_count'] as int,
+  );
 }
 
 Map<String, dynamic> _$PollOptionToJson(PollOption instance) {
@@ -671,13 +713,14 @@ Map<String, dynamic> _$PollOptionToJson(PollOption instance) {
 
 Poll _$PollFromJson(Map<String, dynamic> json) {
   return Poll(
-      id: json['id'] as String,
-      question: json['question'] as String,
-      options: (json['options'] as List)
-          ?.map((e) =>
-              e == null ? null : PollOption.fromJson(e as Map<String, dynamic>))
-          ?.toList(),
-      is_closed: json['is_closed'] as bool);
+    id: json['id'] as String,
+    question: json['question'] as String,
+    options: (json['options'] as List)
+        ?.map((e) =>
+            e == null ? null : PollOption.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    is_closed: json['is_closed'] as bool,
+  );
 }
 
 Map<String, dynamic> _$PollToJson(Poll instance) {
@@ -698,14 +741,15 @@ Map<String, dynamic> _$PollToJson(Poll instance) {
 
 UserProfilePhotos _$UserProfilePhotosFromJson(Map<String, dynamic> json) {
   return UserProfilePhotos(
-      total_count: json['total_count'] as int,
-      photos: (json['photos'] as List)
-          ?.map((e) => (e as List)
-              ?.map((e) => e == null
-                  ? null
-                  : PhotoSize.fromJson(e as Map<String, dynamic>))
-              ?.toList())
-          ?.toList());
+    total_count: json['total_count'] as int,
+    photos: (json['photos'] as List)
+        ?.map((e) => (e as List)
+            ?.map((e) => e == null
+                ? null
+                : PhotoSize.fromJson(e as Map<String, dynamic>))
+            ?.toList())
+        ?.toList(),
+  );
 }
 
 Map<String, dynamic> _$UserProfilePhotosToJson(UserProfilePhotos instance) {
@@ -724,9 +768,10 @@ Map<String, dynamic> _$UserProfilePhotosToJson(UserProfilePhotos instance) {
 
 File _$FileFromJson(Map<String, dynamic> json) {
   return File(
-      file_id: json['file_id'] as String,
-      file_size: json['file_size'] as int,
-      file_path: json['file_path'] as String);
+    file_id: json['file_id'] as String,
+    file_size: json['file_size'] as int,
+    file_path: json['file_path'] as String,
+  );
 }
 
 Map<String, dynamic> _$FileToJson(File instance) {
@@ -753,16 +798,17 @@ Map<String, dynamic> _$ReplyMarkupToJson(ReplyMarkup instance) =>
 
 ReplyKeyboardMarkup _$ReplyKeyboardMarkupFromJson(Map<String, dynamic> json) {
   return ReplyKeyboardMarkup(
-      keyboard: (json['keyboard'] as List)
-          ?.map((e) => (e as List)
-              ?.map((e) => e == null
-                  ? null
-                  : KeyboardButton.fromJson(e as Map<String, dynamic>))
-              ?.toList())
-          ?.toList(),
-      resize_keyboard: json['resize_keyboard'] as bool,
-      one_time_keyboard: json['one_time_keyboard'] as bool,
-      selective: json['selective'] as bool);
+    keyboard: (json['keyboard'] as List)
+        ?.map((e) => (e as List)
+            ?.map((e) => e == null
+                ? null
+                : KeyboardButton.fromJson(e as Map<String, dynamic>))
+            ?.toList())
+        ?.toList(),
+    resize_keyboard: json['resize_keyboard'] as bool,
+    one_time_keyboard: json['one_time_keyboard'] as bool,
+    selective: json['selective'] as bool,
+  );
 }
 
 Map<String, dynamic> _$ReplyKeyboardMarkupToJson(ReplyKeyboardMarkup instance) {
@@ -783,9 +829,10 @@ Map<String, dynamic> _$ReplyKeyboardMarkupToJson(ReplyKeyboardMarkup instance) {
 
 KeyboardButton _$KeyboardButtonFromJson(Map<String, dynamic> json) {
   return KeyboardButton(
-      text: json['text'] as String,
-      request_contact: json['request_contact'] as bool,
-      request_location: json['request_location'] as bool);
+    text: json['text'] as String,
+    request_contact: json['request_contact'] as bool,
+    request_location: json['request_location'] as bool,
+  );
 }
 
 Map<String, dynamic> _$KeyboardButtonToJson(KeyboardButton instance) {
@@ -805,8 +852,9 @@ Map<String, dynamic> _$KeyboardButtonToJson(KeyboardButton instance) {
 
 ReplyKeyboardRemove _$ReplyKeyboardRemoveFromJson(Map<String, dynamic> json) {
   return ReplyKeyboardRemove(
-      remove_keyboard: json['remove_keyboard'] as bool,
-      selective: json['selective'] as bool);
+    remove_keyboard: json['remove_keyboard'] as bool,
+    selective: json['selective'] as bool,
+  );
 }
 
 Map<String, dynamic> _$ReplyKeyboardRemoveToJson(ReplyKeyboardRemove instance) {
@@ -825,13 +873,14 @@ Map<String, dynamic> _$ReplyKeyboardRemoveToJson(ReplyKeyboardRemove instance) {
 
 InlineKeyboardMarkup _$InlineKeyboardMarkupFromJson(Map<String, dynamic> json) {
   return InlineKeyboardMarkup(
-      inline_keyboard: (json['inline_keyboard'] as List)
-          ?.map((e) => (e as List)
-              ?.map((e) => e == null
-                  ? null
-                  : InlineKeyboardButton.fromJson(e as Map<String, dynamic>))
-              ?.toList())
-          ?.toList());
+    inline_keyboard: (json['inline_keyboard'] as List)
+        ?.map((e) => (e as List)
+            ?.map((e) => e == null
+                ? null
+                : InlineKeyboardButton.fromJson(e as Map<String, dynamic>))
+            ?.toList())
+        ?.toList(),
+  );
 }
 
 Map<String, dynamic> _$InlineKeyboardMarkupToJson(
@@ -850,17 +899,17 @@ Map<String, dynamic> _$InlineKeyboardMarkupToJson(
 
 InlineKeyboardButton _$InlineKeyboardButtonFromJson(Map<String, dynamic> json) {
   return InlineKeyboardButton(
-      text: json['text'] as String,
-      url: json['url'] as String,
-      callback_data: json['callback_data'] as String,
-      switch_inline_query: json['switch_inline_query'] as String,
-      switch_inline_query_current_chat:
-          json['switch_inline_query_current_chat'] as String,
-      callback_game: json['callback_game'] == null
-          ? null
-          : CallbackGame.fromJson(
-              json['callback_game'] as Map<String, dynamic>),
-      pay: json['pay'] as bool);
+    text: json['text'] as String,
+    url: json['url'] as String,
+    callback_data: json['callback_data'] as String,
+    switch_inline_query: json['switch_inline_query'] as String,
+    switch_inline_query_current_chat:
+        json['switch_inline_query_current_chat'] as String,
+    callback_game: json['callback_game'] == null
+        ? null
+        : CallbackGame.fromJson(json['callback_game'] as Map<String, dynamic>),
+    pay: json['pay'] as bool,
+  );
 }
 
 Map<String, dynamic> _$InlineKeyboardButtonToJson(
@@ -886,17 +935,18 @@ Map<String, dynamic> _$InlineKeyboardButtonToJson(
 
 CallbackQuery _$CallbackQueryFromJson(Map<String, dynamic> json) {
   return CallbackQuery(
-      id: json['id'] as String,
-      from: json['from'] == null
-          ? null
-          : User.fromJson(json['from'] as Map<String, dynamic>),
-      message: json['message'] == null
-          ? null
-          : Message.fromJson(json['message'] as Map<String, dynamic>),
-      inline_message_id: json['inline_message_id'] as String,
-      chat_instance: json['chat_instance'] as String,
-      data: json['data'] as String,
-      game_short_name: json['game_short_name'] as String);
+    id: json['id'] as String,
+    from: json['from'] == null
+        ? null
+        : User.fromJson(json['from'] as Map<String, dynamic>),
+    message: json['message'] == null
+        ? null
+        : Message.fromJson(json['message'] as Map<String, dynamic>),
+    inline_message_id: json['inline_message_id'] as String,
+    chat_instance: json['chat_instance'] as String,
+    data: json['data'] as String,
+    game_short_name: json['game_short_name'] as String,
+  );
 }
 
 Map<String, dynamic> _$CallbackQueryToJson(CallbackQuery instance) {
@@ -920,8 +970,9 @@ Map<String, dynamic> _$CallbackQueryToJson(CallbackQuery instance) {
 
 ForceReply _$ForceReplyFromJson(Map<String, dynamic> json) {
   return ForceReply(
-      force_reply: json['force_reply'] as bool,
-      selective: json['selective'] as bool);
+    force_reply: json['force_reply'] as bool,
+    selective: json['selective'] as bool,
+  );
 }
 
 Map<String, dynamic> _$ForceReplyToJson(ForceReply instance) {
@@ -940,8 +991,9 @@ Map<String, dynamic> _$ForceReplyToJson(ForceReply instance) {
 
 ChatPhoto _$ChatPhotoFromJson(Map<String, dynamic> json) {
   return ChatPhoto(
-      small_file_id: json['small_file_id'] as String,
-      big_file_id: json['big_file_id'] as String);
+    small_file_id: json['small_file_id'] as String,
+    big_file_id: json['big_file_id'] as String,
+  );
 }
 
 Map<String, dynamic> _$ChatPhotoToJson(ChatPhoto instance) {
@@ -960,25 +1012,26 @@ Map<String, dynamic> _$ChatPhotoToJson(ChatPhoto instance) {
 
 ChatMember _$ChatMemberFromJson(Map<String, dynamic> json) {
   return ChatMember(
-      user: json['user'] == null
-          ? null
-          : User.fromJson(json['user'] as Map<String, dynamic>),
-      status: json['status'] as String,
-      until_date: json['until_date'] as int,
-      can_be_edited: json['can_be_edited'] as bool,
-      can_change_info: json['can_change_info'] as bool,
-      can_post_messages: json['can_post_messages'] as bool,
-      can_edit_messages: json['can_edit_messages'] as bool,
-      can_delete_messages: json['can_delete_messages'] as bool,
-      can_invite_users: json['can_invite_users'] as bool,
-      can_restrict_members: json['can_restrict_members'] as bool,
-      can_pin_messages: json['can_pin_messages'] as bool,
-      can_promote_members: json['can_promote_members'] as bool,
-      is_member: json['is_member'] as bool,
-      can_send_messages: json['can_send_messages'] as bool,
-      can_send_media_messages: json['can_send_media_messages'] as bool,
-      can_send_other_messages: json['can_send_other_messages'] as bool,
-      can_add_web_page_previews: json['can_add_web_page_previews'] as bool);
+    user: json['user'] == null
+        ? null
+        : User.fromJson(json['user'] as Map<String, dynamic>),
+    status: json['status'] as String,
+    until_date: json['until_date'] as int,
+    can_be_edited: json['can_be_edited'] as bool,
+    can_change_info: json['can_change_info'] as bool,
+    can_post_messages: json['can_post_messages'] as bool,
+    can_edit_messages: json['can_edit_messages'] as bool,
+    can_delete_messages: json['can_delete_messages'] as bool,
+    can_invite_users: json['can_invite_users'] as bool,
+    can_restrict_members: json['can_restrict_members'] as bool,
+    can_pin_messages: json['can_pin_messages'] as bool,
+    can_promote_members: json['can_promote_members'] as bool,
+    is_member: json['is_member'] as bool,
+    can_send_messages: json['can_send_messages'] as bool,
+    can_send_media_messages: json['can_send_media_messages'] as bool,
+    can_send_other_messages: json['can_send_other_messages'] as bool,
+    can_add_web_page_previews: json['can_add_web_page_previews'] as bool,
+  );
 }
 
 Map<String, dynamic> _$ChatMemberToJson(ChatMember instance) {
@@ -1012,8 +1065,9 @@ Map<String, dynamic> _$ChatMemberToJson(ChatMember instance) {
 
 ResponseParameters _$ResponseParametersFromJson(Map<String, dynamic> json) {
   return ResponseParameters(
-      migrate_to_chat_id: json['migrate_to_chat_id'] as int,
-      retry_after: json['retry_after'] as int);
+    migrate_to_chat_id: json['migrate_to_chat_id'] as int,
+    retry_after: json['retry_after'] as int,
+  );
 }
 
 Map<String, dynamic> _$ResponseParametersToJson(ResponseParameters instance) {
@@ -1032,10 +1086,11 @@ Map<String, dynamic> _$ResponseParametersToJson(ResponseParameters instance) {
 
 InputMedia _$InputMediaFromJson(Map<String, dynamic> json) {
   return InputMedia(
-      type: json['type'] as String,
-      media: json['media'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String);
+    type: json['type'] as String,
+    media: json['media'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+  );
 }
 
 Map<String, dynamic> _$InputMediaToJson(InputMedia instance) {
@@ -1056,10 +1111,11 @@ Map<String, dynamic> _$InputMediaToJson(InputMedia instance) {
 
 InputMediaPhoto _$InputMediaPhotoFromJson(Map<String, dynamic> json) {
   return InputMediaPhoto(
-      type: json['type'] as String,
-      media: json['media'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String);
+    type: json['type'] as String,
+    media: json['media'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+  );
 }
 
 Map<String, dynamic> _$InputMediaPhotoToJson(InputMediaPhoto instance) {
@@ -1080,15 +1136,16 @@ Map<String, dynamic> _$InputMediaPhotoToJson(InputMediaPhoto instance) {
 
 InputMediaVideo _$InputMediaVideoFromJson(Map<String, dynamic> json) {
   return InputMediaVideo(
-      type: json['type'] as String,
-      media: json['media'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      thumb: json['thumb'],
-      width: json['width'] as int,
-      height: json['height'] as int,
-      duration: json['duration'] as int,
-      supports_streaming: json['supports_streaming'] as bool);
+    type: json['type'] as String,
+    media: json['media'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    thumb: json['thumb'],
+    width: json['width'] as int,
+    height: json['height'] as int,
+    duration: json['duration'] as int,
+    supports_streaming: json['supports_streaming'] as bool,
+  );
 }
 
 Map<String, dynamic> _$InputMediaVideoToJson(InputMediaVideo instance) {
@@ -1114,14 +1171,15 @@ Map<String, dynamic> _$InputMediaVideoToJson(InputMediaVideo instance) {
 
 InputMediaAnimation _$InputMediaAnimationFromJson(Map<String, dynamic> json) {
   return InputMediaAnimation(
-      type: json['type'] as String,
-      media: json['media'] as String,
-      thumb: json['thumb'],
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      width: json['width'] as int,
-      height: json['height'] as int,
-      duration: json['duration'] as int);
+    type: json['type'] as String,
+    media: json['media'] as String,
+    thumb: json['thumb'],
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    width: json['width'] as int,
+    height: json['height'] as int,
+    duration: json['duration'] as int,
+  );
 }
 
 Map<String, dynamic> _$InputMediaAnimationToJson(InputMediaAnimation instance) {
@@ -1146,14 +1204,15 @@ Map<String, dynamic> _$InputMediaAnimationToJson(InputMediaAnimation instance) {
 
 InputMediaAudio _$InputMediaAudioFromJson(Map<String, dynamic> json) {
   return InputMediaAudio(
-      type: json['type'] as String,
-      media: json['media'] as String,
-      thumb: json['thumb'],
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      duration: json['duration'] as int,
-      performer: json['performer'] as String,
-      title: json['title'] as String);
+    type: json['type'] as String,
+    media: json['media'] as String,
+    thumb: json['thumb'],
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    duration: json['duration'] as int,
+    performer: json['performer'] as String,
+    title: json['title'] as String,
+  );
 }
 
 Map<String, dynamic> _$InputMediaAudioToJson(InputMediaAudio instance) {
@@ -1178,11 +1237,12 @@ Map<String, dynamic> _$InputMediaAudioToJson(InputMediaAudio instance) {
 
 InputMediaDocument _$InputMediaDocumentFromJson(Map<String, dynamic> json) {
   return InputMediaDocument(
-      type: json['type'] as String,
-      media: json['media'] as String,
-      thumb: json['thumb'],
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String);
+    type: json['type'] as String,
+    media: json['media'] as String,
+    thumb: json['thumb'],
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+  );
 }
 
 Map<String, dynamic> _$InputMediaDocumentToJson(InputMediaDocument instance) {
@@ -1204,19 +1264,19 @@ Map<String, dynamic> _$InputMediaDocumentToJson(InputMediaDocument instance) {
 
 Sticker _$StickerFromJson(Map<String, dynamic> json) {
   return Sticker(
-      file_id: json['file_id'] as String,
-      width: json['width'] as int,
-      height: json['height'] as int,
-      thumb: json['thumb'] == null
-          ? null
-          : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>),
-      emoji: json['emoji'] as String,
-      set_name: json['set_name'] as String,
-      mask_position: json['mask_position'] == null
-          ? null
-          : MaskPosition.fromJson(
-              json['mask_position'] as Map<String, dynamic>),
-      file_size: json['file_size'] as int);
+    file_id: json['file_id'] as String,
+    width: json['width'] as int,
+    height: json['height'] as int,
+    thumb: json['thumb'] == null
+        ? null
+        : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>),
+    emoji: json['emoji'] as String,
+    set_name: json['set_name'] as String,
+    mask_position: json['mask_position'] == null
+        ? null
+        : MaskPosition.fromJson(json['mask_position'] as Map<String, dynamic>),
+    file_size: json['file_size'] as int,
+  );
 }
 
 Map<String, dynamic> _$StickerToJson(Sticker instance) {
@@ -1241,13 +1301,14 @@ Map<String, dynamic> _$StickerToJson(Sticker instance) {
 
 StickerSet _$StickerSetFromJson(Map<String, dynamic> json) {
   return StickerSet(
-      name: json['name'] as String,
-      title: json['title'] as String,
-      contains_masks: json['contains_masks'] as bool,
-      stickers: (json['stickers'] as List)
-          ?.map((e) =>
-              e == null ? null : Sticker.fromJson(e as Map<String, dynamic>))
-          ?.toList());
+    name: json['name'] as String,
+    title: json['title'] as String,
+    contains_masks: json['contains_masks'] as bool,
+    stickers: (json['stickers'] as List)
+        ?.map((e) =>
+            e == null ? null : Sticker.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
 }
 
 Map<String, dynamic> _$StickerSetToJson(StickerSet instance) {
@@ -1268,10 +1329,11 @@ Map<String, dynamic> _$StickerSetToJson(StickerSet instance) {
 
 MaskPosition _$MaskPositionFromJson(Map<String, dynamic> json) {
   return MaskPosition(
-      point: json['point'] as String,
-      x_shift: (json['x_shift'] as num)?.toDouble(),
-      y_shift: (json['y_shift'] as num)?.toDouble(),
-      scale: (json['scale'] as num)?.toDouble());
+    point: json['point'] as String,
+    x_shift: (json['x_shift'] as num)?.toDouble(),
+    y_shift: (json['y_shift'] as num)?.toDouble(),
+    scale: (json['scale'] as num)?.toDouble(),
+  );
 }
 
 Map<String, dynamic> _$MaskPositionToJson(MaskPosition instance) {
@@ -1292,15 +1354,16 @@ Map<String, dynamic> _$MaskPositionToJson(MaskPosition instance) {
 
 InlineQuery _$InlineQueryFromJson(Map<String, dynamic> json) {
   return InlineQuery(
-      id: json['id'] as String,
-      from: json['from'] == null
-          ? null
-          : User.fromJson(json['from'] as Map<String, dynamic>),
-      location: json['location'] == null
-          ? null
-          : Location.fromJson(json['location'] as Map<String, dynamic>),
-      query: json['query'] as String,
-      offset: json['offset'] as String);
+    id: json['id'] as String,
+    from: json['from'] == null
+        ? null
+        : User.fromJson(json['from'] as Map<String, dynamic>),
+    location: json['location'] == null
+        ? null
+        : Location.fromJson(json['location'] as Map<String, dynamic>),
+    query: json['query'] as String,
+    offset: json['offset'] as String,
+  );
 }
 
 Map<String, dynamic> _$InlineQueryToJson(InlineQuery instance) {
@@ -1322,7 +1385,9 @@ Map<String, dynamic> _$InlineQueryToJson(InlineQuery instance) {
 
 InlineQueryResult _$InlineQueryResultFromJson(Map<String, dynamic> json) {
   return InlineQueryResult(
-      type: json['type'] as String, id: json['id'] as String);
+    type: json['type'] as String,
+    id: json['id'] as String,
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultToJson(InlineQueryResult instance) {
@@ -1342,23 +1407,24 @@ Map<String, dynamic> _$InlineQueryResultToJson(InlineQueryResult instance) {
 InlineQueryResultArticle _$InlineQueryResultArticleFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultArticle(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      title: json['title'] as String,
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>),
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      url: json['url'] as String,
-      hide_url: json['hide_url'] as bool,
-      description: json['description'] as String,
-      thumb_url: json['thumb_url'] as String,
-      thumb_width: json['thumb_width'] as String,
-      thumb_height: json['thumb_height'] as String);
+    id: json['id'] as String,
+    type: json['type'] as String,
+    title: json['title'] as String,
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    url: json['url'] as String,
+    hide_url: json['hide_url'] as bool,
+    description: json['description'] as String,
+    thumb_url: json['thumb_url'] as String,
+    thumb_width: json['thumb_width'] as String,
+    thumb_height: json['thumb_height'] as String,
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultArticleToJson(
@@ -1388,24 +1454,25 @@ Map<String, dynamic> _$InlineQueryResultArticleToJson(
 InlineQueryResultPhoto _$InlineQueryResultPhotoFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultPhoto(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      photo_url: json['photo_url'] as String,
-      thumb_url: json['thumb_url'] as String,
-      photo_width: json['photo_width'] as int,
-      photo_height: json['photo_height'] as int,
-      title: json['title'] as String,
-      description: json['description'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    photo_url: json['photo_url'] as String,
+    thumb_url: json['thumb_url'] as String,
+    photo_width: json['photo_width'] as int,
+    photo_height: json['photo_height'] as int,
+    title: json['title'] as String,
+    description: json['description'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultPhotoToJson(
@@ -1435,24 +1502,25 @@ Map<String, dynamic> _$InlineQueryResultPhotoToJson(
 
 InlineQueryResultGif _$InlineQueryResultGifFromJson(Map<String, dynamic> json) {
   return InlineQueryResultGif(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      gif_url: json['gif_url'] as String,
-      gif_width: json['gif_width'] as int,
-      gif_height: json['gif_height'] as int,
-      gif_duration: json['gif_duration'] as int,
-      thumb_url: json['thumb_url'] as String,
-      title: json['title'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    gif_url: json['gif_url'] as String,
+    gif_width: json['gif_width'] as int,
+    gif_height: json['gif_height'] as int,
+    gif_duration: json['gif_duration'] as int,
+    thumb_url: json['thumb_url'] as String,
+    title: json['title'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultGifToJson(
@@ -1483,24 +1551,25 @@ Map<String, dynamic> _$InlineQueryResultGifToJson(
 InlineQueryResultMpeg4Gif _$InlineQueryResultMpeg4GifFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultMpeg4Gif(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      mpeg4_url: json['mpeg4_url'] as String,
-      mpeg4_width: json['mpeg4_width'] as int,
-      mpeg4_height: json['mpeg4_height'] as int,
-      mpeg4_duration: json['mpeg4_duration'] as int,
-      thumb_url: json['thumb_url'] as String,
-      title: json['title'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    mpeg4_url: json['mpeg4_url'] as String,
+    mpeg4_width: json['mpeg4_width'] as int,
+    mpeg4_height: json['mpeg4_height'] as int,
+    mpeg4_duration: json['mpeg4_duration'] as int,
+    thumb_url: json['thumb_url'] as String,
+    title: json['title'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultMpeg4GifToJson(
@@ -1531,26 +1600,27 @@ Map<String, dynamic> _$InlineQueryResultMpeg4GifToJson(
 InlineQueryResultVideo _$InlineQueryResultVideoFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultVideo(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      video_url: json['video_url'] as String,
-      mime_type: json['mime_type'] as String,
-      thumb_url: json['thumb_url'] as String,
-      title: json['title'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      video_width: json['video_width'] as int,
-      video_height: json['video_height'] as int,
-      video_duration: json['video_duration'] as int,
-      description: json['description'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    video_url: json['video_url'] as String,
+    mime_type: json['mime_type'] as String,
+    thumb_url: json['thumb_url'] as String,
+    title: json['title'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    video_width: json['video_width'] as int,
+    video_height: json['video_height'] as int,
+    video_duration: json['video_duration'] as int,
+    description: json['description'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultVideoToJson(
@@ -1583,22 +1653,23 @@ Map<String, dynamic> _$InlineQueryResultVideoToJson(
 InlineQueryResultAudio _$InlineQueryResultAudioFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultAudio(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      audio_url: json['audio_url'] as String,
-      title: json['title'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      performer: json['performer'] as String,
-      audio_duration: json['audio_duration'] as int,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    audio_url: json['audio_url'] as String,
+    title: json['title'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    performer: json['performer'] as String,
+    audio_duration: json['audio_duration'] as int,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultAudioToJson(
@@ -1627,21 +1698,22 @@ Map<String, dynamic> _$InlineQueryResultAudioToJson(
 InlineQueryResultVoice _$InlineQueryResultVoiceFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultVoice(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      voice_url: json['voice_url'] as String,
-      title: json['title'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      voice_duration: json['voice_duration'] as int,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    voice_url: json['voice_url'] as String,
+    title: json['title'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    voice_duration: json['voice_duration'] as int,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultVoiceToJson(
@@ -1669,25 +1741,26 @@ Map<String, dynamic> _$InlineQueryResultVoiceToJson(
 InlineQueryResultDocument _$InlineQueryResultDocumentFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultDocument(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      title: json['title'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      document_url: json['document_url'] as String,
-      mime_type: json['mime_type'] as String,
-      description: json['description'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>),
-      thumb_url: json['thumb_url'] as String,
-      thumb_width: json['thumb_width'] as int,
-      thumb_height: json['thumb_height'] as int);
+    id: json['id'] as String,
+    type: json['type'] as String,
+    title: json['title'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    document_url: json['document_url'] as String,
+    mime_type: json['mime_type'] as String,
+    description: json['description'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+    thumb_url: json['thumb_url'] as String,
+    thumb_width: json['thumb_width'] as int,
+    thumb_height: json['thumb_height'] as int,
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultDocumentToJson(
@@ -1719,23 +1792,24 @@ Map<String, dynamic> _$InlineQueryResultDocumentToJson(
 InlineQueryResultLocation _$InlineQueryResultLocationFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultLocation(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      latitude: (json['latitude'] as num)?.toDouble(),
-      longitude: (json['longitude'] as num)?.toDouble(),
-      title: json['title'] as String,
-      live_period: json['live_period'] as int,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>),
-      thumb_url: json['thumb_url'] as String,
-      thumb_width: json['thumb_width'] as int,
-      thumb_height: json['thumb_height'] as int);
+    id: json['id'] as String,
+    type: json['type'] as String,
+    latitude: (json['latitude'] as num)?.toDouble(),
+    longitude: (json['longitude'] as num)?.toDouble(),
+    title: json['title'] as String,
+    live_period: json['live_period'] as int,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+    thumb_url: json['thumb_url'] as String,
+    thumb_width: json['thumb_width'] as int,
+    thumb_height: json['thumb_height'] as int,
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultLocationToJson(
@@ -1765,25 +1839,26 @@ Map<String, dynamic> _$InlineQueryResultLocationToJson(
 InlineQueryResultVenue _$InlineQueryResultVenueFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultVenue(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      latitude: (json['latitude'] as num)?.toDouble(),
-      longitude: (json['longitude'] as num)?.toDouble(),
-      title: json['title'] as String,
-      address: json['address'] as String,
-      foursquare_id: json['foursquare_id'] as String,
-      foursquare_type: json['foursquare_type'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>),
-      thumb_url: json['thumb_url'] as String,
-      thumb_width: json['thumb_width'] as int,
-      thumb_height: json['thumb_height'] as int);
+    id: json['id'] as String,
+    type: json['type'] as String,
+    latitude: (json['latitude'] as num)?.toDouble(),
+    longitude: (json['longitude'] as num)?.toDouble(),
+    title: json['title'] as String,
+    address: json['address'] as String,
+    foursquare_id: json['foursquare_id'] as String,
+    foursquare_type: json['foursquare_type'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+    thumb_url: json['thumb_url'] as String,
+    thumb_width: json['thumb_width'] as int,
+    thumb_height: json['thumb_height'] as int,
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultVenueToJson(
@@ -1815,23 +1890,24 @@ Map<String, dynamic> _$InlineQueryResultVenueToJson(
 InlineQueryResultContact _$InlineQueryResultContactFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultContact(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      phone_number: json['phone_number'] as String,
-      first_name: json['first_name'] as String,
-      last_name: json['last_name'] as String,
-      vcard: json['vcard'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>),
-      thumb_url: json['thumb_url'] as String,
-      thumb_width: json['thumb_width'] as int,
-      thumb_height: json['thumb_height'] as int);
+    id: json['id'] as String,
+    type: json['type'] as String,
+    phone_number: json['phone_number'] as String,
+    first_name: json['first_name'] as String,
+    last_name: json['last_name'] as String,
+    vcard: json['vcard'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+    thumb_url: json['thumb_url'] as String,
+    thumb_width: json['thumb_width'] as int,
+    thumb_height: json['thumb_height'] as int,
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultContactToJson(
@@ -1861,13 +1937,14 @@ Map<String, dynamic> _$InlineQueryResultContactToJson(
 InlineQueryResultGame _$InlineQueryResultGameFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultGame(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      game_short_name: json['game_short_name'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    game_short_name: json['game_short_name'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultGameToJson(
@@ -1890,21 +1967,22 @@ Map<String, dynamic> _$InlineQueryResultGameToJson(
 InlineQueryResultCachedPhoto _$InlineQueryResultCachedPhotoFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultCachedPhoto(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      photo_file_id: json['photo_file_id'] as String,
-      title: json['title'] as String,
-      description: json['description'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    photo_file_id: json['photo_file_id'] as String,
+    title: json['title'] as String,
+    description: json['description'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultCachedPhotoToJson(
@@ -1932,20 +2010,21 @@ Map<String, dynamic> _$InlineQueryResultCachedPhotoToJson(
 InlineQueryResultCachedGif _$InlineQueryResultCachedGifFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultCachedGif(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      gif_file_id: json['gif_file_id'] as String,
-      title: json['title'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    gif_file_id: json['gif_file_id'] as String,
+    title: json['title'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultCachedGifToJson(
@@ -1972,20 +2051,21 @@ Map<String, dynamic> _$InlineQueryResultCachedGifToJson(
 InlineQueryResultCachedMpeg4Gif _$InlineQueryResultCachedMpeg4GifFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultCachedMpeg4Gif(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      mpeg4_file_id: json['mpeg4_file_id'] as String,
-      title: json['title'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    mpeg4_file_id: json['mpeg4_file_id'] as String,
+    title: json['title'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultCachedMpeg4GifToJson(
@@ -2012,17 +2092,18 @@ Map<String, dynamic> _$InlineQueryResultCachedMpeg4GifToJson(
 InlineQueryResultCachedSticker _$InlineQueryResultCachedStickerFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultCachedSticker(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      sticker_file_id: json['sticker_file_id'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    sticker_file_id: json['sticker_file_id'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultCachedStickerToJson(
@@ -2046,21 +2127,22 @@ Map<String, dynamic> _$InlineQueryResultCachedStickerToJson(
 InlineQueryResultCachedDocument _$InlineQueryResultCachedDocumentFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultCachedDocument(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      title: json['title'] as String,
-      document_file_id: json['document_file_id'] as String,
-      description: json['description'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    title: json['title'] as String,
+    document_file_id: json['document_file_id'] as String,
+    description: json['description'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultCachedDocumentToJson(
@@ -2088,21 +2170,22 @@ Map<String, dynamic> _$InlineQueryResultCachedDocumentToJson(
 InlineQueryResultCachedVideo _$InlineQueryResultCachedVideoFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultCachedVideo(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      video_file_id: json['video_file_id'] as String,
-      title: json['title'] as String,
-      description: json['description'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    video_file_id: json['video_file_id'] as String,
+    title: json['title'] as String,
+    description: json['description'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultCachedVideoToJson(
@@ -2130,20 +2213,21 @@ Map<String, dynamic> _$InlineQueryResultCachedVideoToJson(
 InlineQueryResultCachedVoice _$InlineQueryResultCachedVoiceFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultCachedVoice(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      voice_file_id: json['voice_file_id'] as String,
-      title: json['title'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    voice_file_id: json['voice_file_id'] as String,
+    title: json['title'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultCachedVoiceToJson(
@@ -2170,19 +2254,20 @@ Map<String, dynamic> _$InlineQueryResultCachedVoiceToJson(
 InlineQueryResultCachedAudio _$InlineQueryResultCachedAudioFromJson(
     Map<String, dynamic> json) {
   return InlineQueryResultCachedAudio(
-      id: json['id'] as String,
-      type: json['type'] as String,
-      audio_file_id: json['audio_file_id'] as String,
-      caption: json['caption'] as String,
-      parse_mode: json['parse_mode'] as String,
-      reply_markup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(
-              json['reply_markup'] as Map<String, dynamic>),
-      input_message_content: json['input_message_content'] == null
-          ? null
-          : InputMessageContent.fromJson(
-              json['input_message_content'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    type: json['type'] as String,
+    audio_file_id: json['audio_file_id'] as String,
+    caption: json['caption'] as String,
+    parse_mode: json['parse_mode'] as String,
+    reply_markup: json['reply_markup'] == null
+        ? null
+        : InlineKeyboardMarkup.fromJson(
+            json['reply_markup'] as Map<String, dynamic>),
+    input_message_content: json['input_message_content'] == null
+        ? null
+        : InputMessageContent.fromJson(
+            json['input_message_content'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$InlineQueryResultCachedAudioToJson(
@@ -2216,9 +2301,10 @@ Map<String, dynamic> _$InputMessageContentToJson(
 InputTextMessageContent _$InputTextMessageContentFromJson(
     Map<String, dynamic> json) {
   return InputTextMessageContent(
-      message_text: json['message_text'] as String,
-      parse_mode: json['parse_mode'] as String,
-      disable_web_page_preview: json['disable_web_page_preview'] as bool);
+    message_text: json['message_text'] as String,
+    parse_mode: json['parse_mode'] as String,
+    disable_web_page_preview: json['disable_web_page_preview'] as bool,
+  );
 }
 
 Map<String, dynamic> _$InputTextMessageContentToJson(
@@ -2240,9 +2326,10 @@ Map<String, dynamic> _$InputTextMessageContentToJson(
 InputLocationMessageContent _$InputLocationMessageContentFromJson(
     Map<String, dynamic> json) {
   return InputLocationMessageContent(
-      latitude: (json['latitude'] as num)?.toDouble(),
-      longitude: (json['longitude'] as num)?.toDouble(),
-      live_period: json['live_period'] as int);
+    latitude: (json['latitude'] as num)?.toDouble(),
+    longitude: (json['longitude'] as num)?.toDouble(),
+    live_period: json['live_period'] as int,
+  );
 }
 
 Map<String, dynamic> _$InputLocationMessageContentToJson(
@@ -2264,12 +2351,13 @@ Map<String, dynamic> _$InputLocationMessageContentToJson(
 InputVenueMessageContent _$InputVenueMessageContentFromJson(
     Map<String, dynamic> json) {
   return InputVenueMessageContent(
-      latitude: (json['latitude'] as num)?.toDouble(),
-      longitude: (json['longitude'] as num)?.toDouble(),
-      title: json['title'] as String,
-      address: json['address'] as String,
-      foursquare_id: json['foursquare_id'] as String,
-      foursquare_type: json['foursquare_type'] as String);
+    latitude: (json['latitude'] as num)?.toDouble(),
+    longitude: (json['longitude'] as num)?.toDouble(),
+    title: json['title'] as String,
+    address: json['address'] as String,
+    foursquare_id: json['foursquare_id'] as String,
+    foursquare_type: json['foursquare_type'] as String,
+  );
 }
 
 Map<String, dynamic> _$InputVenueMessageContentToJson(
@@ -2294,10 +2382,11 @@ Map<String, dynamic> _$InputVenueMessageContentToJson(
 InputContactMessageContent _$InputContactMessageContentFromJson(
     Map<String, dynamic> json) {
   return InputContactMessageContent(
-      phone_number: json['phone_number'] as String,
-      first_name: json['first_name'] as String,
-      last_name: json['last_name'] as String,
-      vcard: json['vcard'] as String);
+    phone_number: json['phone_number'] as String,
+    first_name: json['first_name'] as String,
+    last_name: json['last_name'] as String,
+    vcard: json['vcard'] as String,
+  );
 }
 
 Map<String, dynamic> _$InputContactMessageContentToJson(
@@ -2319,15 +2408,16 @@ Map<String, dynamic> _$InputContactMessageContentToJson(
 
 ChosenInlineResult _$ChosenInlineResultFromJson(Map<String, dynamic> json) {
   return ChosenInlineResult(
-      result_id: json['result_id'] as String,
-      from: json['from'] == null
-          ? null
-          : User.fromJson(json['from'] as Map<String, dynamic>),
-      location: json['location'] == null
-          ? null
-          : Location.fromJson(json['location'] as Map<String, dynamic>),
-      inline_message_id: json['inline_message_id'] as String,
-      query: json['query'] as String);
+    result_id: json['result_id'] as String,
+    from: json['from'] == null
+        ? null
+        : User.fromJson(json['from'] as Map<String, dynamic>),
+    location: json['location'] == null
+        ? null
+        : Location.fromJson(json['location'] as Map<String, dynamic>),
+    inline_message_id: json['inline_message_id'] as String,
+    query: json['query'] as String,
+  );
 }
 
 Map<String, dynamic> _$ChosenInlineResultToJson(ChosenInlineResult instance) {
@@ -2349,7 +2439,9 @@ Map<String, dynamic> _$ChosenInlineResultToJson(ChosenInlineResult instance) {
 
 LabeledPrice _$LabeledPriceFromJson(Map<String, dynamic> json) {
   return LabeledPrice(
-      label: json['label'] as String, amount: json['amount'] as int);
+    label: json['label'] as String,
+    amount: json['amount'] as int,
+  );
 }
 
 Map<String, dynamic> _$LabeledPriceToJson(LabeledPrice instance) {
@@ -2368,11 +2460,12 @@ Map<String, dynamic> _$LabeledPriceToJson(LabeledPrice instance) {
 
 Invoice _$InvoiceFromJson(Map<String, dynamic> json) {
   return Invoice(
-      title: json['title'] as String,
-      description: json['description'] as String,
-      start_parameter: json['start_parameter'] as String,
-      currency: json['currency'] as String,
-      total_amount: json['total_amount'] as int);
+    title: json['title'] as String,
+    description: json['description'] as String,
+    start_parameter: json['start_parameter'] as String,
+    currency: json['currency'] as String,
+    total_amount: json['total_amount'] as int,
+  );
 }
 
 Map<String, dynamic> _$InvoiceToJson(Invoice instance) {
@@ -2394,12 +2487,13 @@ Map<String, dynamic> _$InvoiceToJson(Invoice instance) {
 
 ShippingAddress _$ShippingAddressFromJson(Map<String, dynamic> json) {
   return ShippingAddress(
-      country_code: json['country_code'] as String,
-      state: json['state'] as String,
-      city: json['city'] as String,
-      street_line1: json['street_line1'] as String,
-      street_line2: json['street_line2'] as String,
-      post_code: json['post_code'] as String);
+    country_code: json['country_code'] as String,
+    state: json['state'] as String,
+    city: json['city'] as String,
+    street_line1: json['street_line1'] as String,
+    street_line2: json['street_line2'] as String,
+    post_code: json['post_code'] as String,
+  );
 }
 
 Map<String, dynamic> _$ShippingAddressToJson(ShippingAddress instance) {
@@ -2422,13 +2516,14 @@ Map<String, dynamic> _$ShippingAddressToJson(ShippingAddress instance) {
 
 OrderInfo _$OrderInfoFromJson(Map<String, dynamic> json) {
   return OrderInfo(
-      name: json['name'] as String,
-      phone_number: json['phone_number'] as String,
-      email: json['email'] as String,
-      shippingAddress: json['shippingAddress'] == null
-          ? null
-          : ShippingAddress.fromJson(
-              json['shippingAddress'] as Map<String, dynamic>));
+    name: json['name'] as String,
+    phone_number: json['phone_number'] as String,
+    email: json['email'] as String,
+    shippingAddress: json['shippingAddress'] == null
+        ? null
+        : ShippingAddress.fromJson(
+            json['shippingAddress'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$OrderInfoToJson(OrderInfo instance) {
@@ -2449,13 +2544,13 @@ Map<String, dynamic> _$OrderInfoToJson(OrderInfo instance) {
 
 ShippingOption _$ShippingOptionFromJson(Map<String, dynamic> json) {
   return ShippingOption(
-      id: json['id'] as String,
-      title: json['title'] as String,
-      prices: (json['prices'] as List)
-          ?.map((e) => e == null
-              ? null
-              : LabeledPrice.fromJson(e as Map<String, dynamic>))
-          ?.toList());
+    id: json['id'] as String,
+    title: json['title'] as String,
+    prices: (json['prices'] as List)
+        ?.map((e) =>
+            e == null ? null : LabeledPrice.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
 }
 
 Map<String, dynamic> _$ShippingOptionToJson(ShippingOption instance) {
@@ -2475,15 +2570,16 @@ Map<String, dynamic> _$ShippingOptionToJson(ShippingOption instance) {
 
 SuccessfulPayment _$SuccessfulPaymentFromJson(Map<String, dynamic> json) {
   return SuccessfulPayment(
-      currency: json['currency'] as String,
-      total_amount: json['total_amount'] as int,
-      invoice_payload: json['invoice_payload'] as String,
-      shipping_option_id: json['shipping_option_id'] as String,
-      order_info: json['order_info'] == null
-          ? null
-          : OrderInfo.fromJson(json['order_info'] as Map<String, dynamic>),
-      telegram_payment_charge_id: json['telegram_payment_charge_id'] as String,
-      provider_payment_charge_id: json['provider_payment_charge_id'] as String);
+    currency: json['currency'] as String,
+    total_amount: json['total_amount'] as int,
+    invoice_payload: json['invoice_payload'] as String,
+    shipping_option_id: json['shipping_option_id'] as String,
+    order_info: json['order_info'] == null
+        ? null
+        : OrderInfo.fromJson(json['order_info'] as Map<String, dynamic>),
+    telegram_payment_charge_id: json['telegram_payment_charge_id'] as String,
+    provider_payment_charge_id: json['provider_payment_charge_id'] as String,
+  );
 }
 
 Map<String, dynamic> _$SuccessfulPaymentToJson(SuccessfulPayment instance) {
@@ -2509,15 +2605,16 @@ Map<String, dynamic> _$SuccessfulPaymentToJson(SuccessfulPayment instance) {
 
 ShippingQuery _$ShippingQueryFromJson(Map<String, dynamic> json) {
   return ShippingQuery(
-      id: json['id'] as String,
-      from: json['from'] == null
-          ? null
-          : User.fromJson(json['from'] as Map<String, dynamic>),
-      invoice_payload: json['invoice_payload'] as String,
-      shipping_address: json['shipping_address'] == null
-          ? null
-          : ShippingAddress.fromJson(
-              json['shipping_address'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    from: json['from'] == null
+        ? null
+        : User.fromJson(json['from'] as Map<String, dynamic>),
+    invoice_payload: json['invoice_payload'] as String,
+    shipping_address: json['shipping_address'] == null
+        ? null
+        : ShippingAddress.fromJson(
+            json['shipping_address'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$ShippingQueryToJson(ShippingQuery instance) {
@@ -2538,17 +2635,18 @@ Map<String, dynamic> _$ShippingQueryToJson(ShippingQuery instance) {
 
 PreCheckoutQuery _$PreCheckoutQueryFromJson(Map<String, dynamic> json) {
   return PreCheckoutQuery(
-      id: json['id'] as String,
-      from: json['from'] == null
-          ? null
-          : User.fromJson(json['from'] as Map<String, dynamic>),
-      currency: json['currency'] as String,
-      total_amount: json['total_amount'] as int,
-      invoice_payload: json['invoice_payload'] as String,
-      shipping_option_id: json['shipping_option_id'] as String,
-      order_info: json['order_info'] == null
-          ? null
-          : OrderInfo.fromJson(json['order_info'] as Map<String, dynamic>));
+    id: json['id'] as String,
+    from: json['from'] == null
+        ? null
+        : User.fromJson(json['from'] as Map<String, dynamic>),
+    currency: json['currency'] as String,
+    total_amount: json['total_amount'] as int,
+    invoice_payload: json['invoice_payload'] as String,
+    shipping_option_id: json['shipping_option_id'] as String,
+    order_info: json['order_info'] == null
+        ? null
+        : OrderInfo.fromJson(json['order_info'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$PreCheckoutQueryToJson(PreCheckoutQuery instance) {
@@ -2572,15 +2670,16 @@ Map<String, dynamic> _$PreCheckoutQueryToJson(PreCheckoutQuery instance) {
 
 PassportData _$PassportDataFromJson(Map<String, dynamic> json) {
   return PassportData(
-      data: (json['data'] as List)
-          ?.map((e) => e == null
-              ? null
-              : EncryptedPassportElement.fromJson(e as Map<String, dynamic>))
-          ?.toList(),
-      credentials: json['credentials'] == null
-          ? null
-          : EncryptedCredentials.fromJson(
-              json['credentials'] as Map<String, dynamic>));
+    data: (json['data'] as List)
+        ?.map((e) => e == null
+            ? null
+            : EncryptedPassportElement.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    credentials: json['credentials'] == null
+        ? null
+        : EncryptedCredentials.fromJson(
+            json['credentials'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$PassportDataToJson(PassportData instance) {
@@ -2599,9 +2698,10 @@ Map<String, dynamic> _$PassportDataToJson(PassportData instance) {
 
 PassportFile _$PassportFileFromJson(Map<String, dynamic> json) {
   return PassportFile(
-      file_id: json['file_id'] as String,
-      file_size: json['file_size'] as int,
-      file_date: json['file_date'] as int);
+    file_id: json['file_id'] as String,
+    file_size: json['file_size'] as int,
+    file_date: json['file_date'] as int,
+  );
 }
 
 Map<String, dynamic> _$PassportFileToJson(PassportFile instance) {
@@ -2622,30 +2722,29 @@ Map<String, dynamic> _$PassportFileToJson(PassportFile instance) {
 EncryptedPassportElement _$EncryptedPassportElementFromJson(
     Map<String, dynamic> json) {
   return EncryptedPassportElement(
-      type: json['type'] as String,
-      data: json['data'] as String,
-      phone_number: json['phone_number'] as String,
-      email: json['email'] as String,
-      files: (json['files'] as List)
-          ?.map((e) => e == null
-              ? null
-              : PassportFile.fromJson(e as Map<String, dynamic>))
-          ?.toList(),
-      front_side: json['front_side'] == null
-          ? null
-          : PassportFile.fromJson(json['front_side'] as Map<String, dynamic>),
-      reverse_side: json['reverse_side'] == null
-          ? null
-          : PassportFile.fromJson(json['reverse_side'] as Map<String, dynamic>),
-      selfie: json['selfie'] == null
-          ? null
-          : PassportFile.fromJson(json['selfie'] as Map<String, dynamic>),
-      translation: (json['translation'] as List)
-          ?.map((e) => e == null
-              ? null
-              : PassportFile.fromJson(e as Map<String, dynamic>))
-          ?.toList(),
-      hash: json['hash'] as String);
+    type: json['type'] as String,
+    data: json['data'] as String,
+    phone_number: json['phone_number'] as String,
+    email: json['email'] as String,
+    files: (json['files'] as List)
+        ?.map((e) =>
+            e == null ? null : PassportFile.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    front_side: json['front_side'] == null
+        ? null
+        : PassportFile.fromJson(json['front_side'] as Map<String, dynamic>),
+    reverse_side: json['reverse_side'] == null
+        ? null
+        : PassportFile.fromJson(json['reverse_side'] as Map<String, dynamic>),
+    selfie: json['selfie'] == null
+        ? null
+        : PassportFile.fromJson(json['selfie'] as Map<String, dynamic>),
+    translation: (json['translation'] as List)
+        ?.map((e) =>
+            e == null ? null : PassportFile.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    hash: json['hash'] as String,
+  );
 }
 
 Map<String, dynamic> _$EncryptedPassportElementToJson(
@@ -2673,9 +2772,10 @@ Map<String, dynamic> _$EncryptedPassportElementToJson(
 
 EncryptedCredentials _$EncryptedCredentialsFromJson(Map<String, dynamic> json) {
   return EncryptedCredentials(
-      data: json['data'] as String,
-      hash: json['hash'] as String,
-      secret: json['secret'] as String);
+    data: json['data'] as String,
+    hash: json['hash'] as String,
+    secret: json['secret'] as String,
+  );
 }
 
 Map<String, dynamic> _$EncryptedCredentialsToJson(
@@ -2696,9 +2796,10 @@ Map<String, dynamic> _$EncryptedCredentialsToJson(
 
 PassportElementError _$PassportElementErrorFromJson(Map<String, dynamic> json) {
   return PassportElementError(
-      source: json['source'] as String,
-      type: json['type'] as String,
-      message: json['message'] as String);
+    source: json['source'] as String,
+    type: json['type'] as String,
+    message: json['message'] as String,
+  );
 }
 
 Map<String, dynamic> _$PassportElementErrorToJson(
@@ -2720,11 +2821,12 @@ Map<String, dynamic> _$PassportElementErrorToJson(
 PassportElementErrorDataField _$PassportElementErrorDataFieldFromJson(
     Map<String, dynamic> json) {
   return PassportElementErrorDataField(
-      source: json['source'] as String,
-      type: json['type'] as String,
-      message: json['message'] as String,
-      field_name: json['field_name'] as String,
-      data_hash: json['data_hash'] as String);
+    source: json['source'] as String,
+    type: json['type'] as String,
+    message: json['message'] as String,
+    field_name: json['field_name'] as String,
+    data_hash: json['data_hash'] as String,
+  );
 }
 
 Map<String, dynamic> _$PassportElementErrorDataFieldToJson(
@@ -2748,10 +2850,11 @@ Map<String, dynamic> _$PassportElementErrorDataFieldToJson(
 PassportElementErrorFrontSide _$PassportElementErrorFrontSideFromJson(
     Map<String, dynamic> json) {
   return PassportElementErrorFrontSide(
-      source: json['source'] as String,
-      type: json['type'] as String,
-      message: json['message'] as String,
-      file_hash: json['file_hash'] as String);
+    source: json['source'] as String,
+    type: json['type'] as String,
+    message: json['message'] as String,
+    file_hash: json['file_hash'] as String,
+  );
 }
 
 Map<String, dynamic> _$PassportElementErrorFrontSideToJson(
@@ -2774,10 +2877,11 @@ Map<String, dynamic> _$PassportElementErrorFrontSideToJson(
 PassportElementErrorReverseSide _$PassportElementErrorReverseSideFromJson(
     Map<String, dynamic> json) {
   return PassportElementErrorReverseSide(
-      source: json['source'] as String,
-      type: json['type'] as String,
-      message: json['message'] as String,
-      file_hash: json['file_hash'] as String);
+    source: json['source'] as String,
+    type: json['type'] as String,
+    message: json['message'] as String,
+    file_hash: json['file_hash'] as String,
+  );
 }
 
 Map<String, dynamic> _$PassportElementErrorReverseSideToJson(
@@ -2800,10 +2904,11 @@ Map<String, dynamic> _$PassportElementErrorReverseSideToJson(
 PassportElementErrorSelfie _$PassportElementErrorSelfieFromJson(
     Map<String, dynamic> json) {
   return PassportElementErrorSelfie(
-      source: json['source'] as String,
-      type: json['type'] as String,
-      message: json['message'] as String,
-      file_hash: json['file_hash'] as String);
+    source: json['source'] as String,
+    type: json['type'] as String,
+    message: json['message'] as String,
+    file_hash: json['file_hash'] as String,
+  );
 }
 
 Map<String, dynamic> _$PassportElementErrorSelfieToJson(
@@ -2826,10 +2931,11 @@ Map<String, dynamic> _$PassportElementErrorSelfieToJson(
 PassportElementErrorFile _$PassportElementErrorFileFromJson(
     Map<String, dynamic> json) {
   return PassportElementErrorFile(
-      source: json['source'] as String,
-      type: json['type'] as String,
-      message: json['message'] as String,
-      file_hash: json['file_hash'] as String);
+    source: json['source'] as String,
+    type: json['type'] as String,
+    message: json['message'] as String,
+    file_hash: json['file_hash'] as String,
+  );
 }
 
 Map<String, dynamic> _$PassportElementErrorFileToJson(
@@ -2852,11 +2958,12 @@ Map<String, dynamic> _$PassportElementErrorFileToJson(
 PassportElementErrorFiles _$PassportElementErrorFilesFromJson(
     Map<String, dynamic> json) {
   return PassportElementErrorFiles(
-      source: json['source'] as String,
-      type: json['type'] as String,
-      message: json['message'] as String,
-      file_hashes:
-          (json['file_hashes'] as List)?.map((e) => e as String)?.toList());
+    source: json['source'] as String,
+    type: json['type'] as String,
+    message: json['message'] as String,
+    file_hashes:
+        (json['file_hashes'] as List)?.map((e) => e as String)?.toList(),
+  );
 }
 
 Map<String, dynamic> _$PassportElementErrorFilesToJson(
@@ -2879,10 +2986,11 @@ Map<String, dynamic> _$PassportElementErrorFilesToJson(
 PassportElementErrorTranslationFile
     _$PassportElementErrorTranslationFileFromJson(Map<String, dynamic> json) {
   return PassportElementErrorTranslationFile(
-      source: json['source'] as String,
-      type: json['type'] as String,
-      message: json['message'] as String,
-      file_hash: json['file_hash'] as String);
+    source: json['source'] as String,
+    type: json['type'] as String,
+    message: json['message'] as String,
+    file_hash: json['file_hash'] as String,
+  );
 }
 
 Map<String, dynamic> _$PassportElementErrorTranslationFileToJson(
@@ -2905,11 +3013,12 @@ Map<String, dynamic> _$PassportElementErrorTranslationFileToJson(
 PassportElementErrorTranslationFiles
     _$PassportElementErrorTranslationFilesFromJson(Map<String, dynamic> json) {
   return PassportElementErrorTranslationFiles(
-      source: json['source'] as String,
-      type: json['type'] as String,
-      message: json['message'] as String,
-      file_hashes:
-          (json['file_hashes'] as List)?.map((e) => e as String)?.toList());
+    source: json['source'] as String,
+    type: json['type'] as String,
+    message: json['message'] as String,
+    file_hashes:
+        (json['file_hashes'] as List)?.map((e) => e as String)?.toList(),
+  );
 }
 
 Map<String, dynamic> _$PassportElementErrorTranslationFilesToJson(
@@ -2932,10 +3041,11 @@ Map<String, dynamic> _$PassportElementErrorTranslationFilesToJson(
 PassportElementErrorUnspecified _$PassportElementErrorUnspecifiedFromJson(
     Map<String, dynamic> json) {
   return PassportElementErrorUnspecified(
-      source: json['source'] as String,
-      type: json['type'] as String,
-      message: json['message'] as String,
-      file_hash: json['file_hash'] as String);
+    source: json['source'] as String,
+    type: json['type'] as String,
+    message: json['message'] as String,
+    file_hash: json['file_hash'] as String,
+  );
 }
 
 Map<String, dynamic> _$PassportElementErrorUnspecifiedToJson(
@@ -2957,21 +3067,22 @@ Map<String, dynamic> _$PassportElementErrorUnspecifiedToJson(
 
 Game _$GameFromJson(Map<String, dynamic> json) {
   return Game(
-      title: json['title'] as String,
-      description: json['description'] as String,
-      photo: (json['photo'] as List)
-          ?.map((e) =>
-              e == null ? null : PhotoSize.fromJson(e as Map<String, dynamic>))
-          ?.toList(),
-      text: json['text'] as String,
-      text_entities: (json['text_entities'] as List)
-          ?.map((e) => e == null
-              ? null
-              : MessageEntity.fromJson(e as Map<String, dynamic>))
-          ?.toList(),
-      animation: json['animation'] == null
-          ? null
-          : Animation.fromJson(json['animation'] as Map<String, dynamic>));
+    title: json['title'] as String,
+    description: json['description'] as String,
+    photo: (json['photo'] as List)
+        ?.map((e) =>
+            e == null ? null : PhotoSize.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    text: json['text'] as String,
+    text_entities: (json['text_entities'] as List)
+        ?.map((e) => e == null
+            ? null
+            : MessageEntity.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    animation: json['animation'] == null
+        ? null
+        : Animation.fromJson(json['animation'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$GameToJson(Game instance) {
@@ -3001,11 +3112,12 @@ Map<String, dynamic> _$CallbackGameToJson(CallbackGame instance) =>
 
 GameHighScore _$GameHighScoreFromJson(Map<String, dynamic> json) {
   return GameHighScore(
-      position: json['position'] as int,
-      user: json['user'] == null
-          ? null
-          : User.fromJson(json['user'] as Map<String, dynamic>),
-      score: json['score'] as int);
+    position: json['position'] as int,
+    user: json['user'] == null
+        ? null
+        : User.fromJson(json['user'] as Map<String, dynamic>),
+    score: json['score'] as int,
+  );
 }
 
 Map<String, dynamic> _$GameHighScoreToJson(GameHighScore instance) {

--- a/lib/src/telegram/models/login_url.dart
+++ b/lib/src/telegram/models/login_url.dart
@@ -18,30 +18,19 @@
 
 part of '../model.dart';
 
-/// This object represents one button of an inline keyboard.
-/// You **must** use exactly one of the optional fields.
+/// This object represents a point on the map.
 ///
-/// https://core.telegram.org/bots/api#inlinekeyboardbutton
+/// https://core.telegram.org/bots/api#location
 @JsonSerializable()
-class InlineKeyboardButton {
-  String text;
+class LoginUrl {
   String url;
-  LoginUrl login_url;
-  String callback_data;
-  String switch_inline_query;
-  String switch_inline_query_current_chat;
-  CallbackGame callback_game;
-  bool pay;
-  InlineKeyboardButton(
-      {this.text,
-      this.url,
-      this.login_url,
-      this.callback_data,
-      this.switch_inline_query,
-      this.switch_inline_query_current_chat,
-      this.callback_game,
-      this.pay});
-  factory InlineKeyboardButton.fromJson(Map<String, dynamic> json) =>
-      _$InlineKeyboardButtonFromJson(json);
-  Map<String, dynamic> toJson() => _$InlineKeyboardButtonToJson(this);
+  String forward_text;
+  String bot_username;
+  bool request_write_access;
+  LoginUrl(url,
+      {this.forward_text, this.bot_username, this.request_write_access});
+  factory LoginUrl.fromJson(Map<String, dynamic> json) =>
+      _$LoginUrlFromJson(json);
+  Map<String, dynamic> toJson(Map<String, dynamic> json) =>
+      _$LoginUrlToJson(this);
 }

--- a/lib/src/telegram/models/message.dart
+++ b/lib/src/telegram/models/message.dart
@@ -69,6 +69,7 @@ class Message {
   SuccessfulPayment successful_payment;
   String connected_website;
   PassportData passport_data;
+  InlineKeyboardMarkup reply_markup;
 
   Message(
       {this.message_id,
@@ -116,7 +117,8 @@ class Message {
       this.invoice,
       this.successful_payment,
       this.connected_website,
-      this.passport_data});
+      this.passport_data,
+      this.reply_markup});
 
   factory Message.fromJson(Map<String, dynamic> json) =>
       _$MessageFromJson(json);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  json_annotation: ^2.4.0
+  json_annotation: ^3.0.0
   http: ^0.12.0+2
 
 dev_dependencies:
-  test: ^1.6.3
-  build_runner: ^1.4.0
-  json_serializable: ^3.0.0
-  pedantic: ^1.7.0
+  test: ^1.6.5
+  build_runner: ^1.6.5
+  json_serializable: ^3.1.0
+  pedantic: ^1.8.0
 


### PR DESCRIPTION
#61 

- [x] Seamless Telegram Login (No actions required)
- [x] new object LoginUrl
- [x] new field login_url to the InlineKeyboardButton object
- [x] Added the field reply_markup to the Message object
- [x] If a message with an inline keyboard is forwarded, the forwarded message will now have an inline keyboard if the keyboard contained only url and login_url buttons or if the message was sent via a bot and the keyboard contained only url, login_url, switch_inline_query or switch_inline_query_current_chat buttons. In the latter case, switch_inline_query_current_chat buttons are replaced with switch_inline_query buttons. (No actions required)
- [ ] Bots now receive the edited_message Update even if only Message.reply_markup has changed. (No actions required)
- [ ] Bots that have the can_edit_messages right in a channel can now use the method editMessageReplyMarkup for messages written by other administrators forever without the 48 hours limit. (No actions required)
- [ ] webhook requests from Bot API will be coming from the subnets 149.154.160.0/20 and 91.108.4.0/22 (No actions required)