### PR TITLE
API 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased
 
 - Support API 4.3
+- Sypport API 4.4
 
 ## 0.0.33
 

--- a/lib/src/telegram/model.dart
+++ b/lib/src/telegram/model.dart
@@ -51,6 +51,7 @@ part 'models/callback_query.dart';
 part 'models/force_reply.dart';
 part 'models/chat_photo.dart';
 part 'models/chat_member.dart';
+part 'models/chat_permissions.dart';
 part 'models/response_parameters.dart';
 part 'models/input_media.dart';
 part 'models/input_media_photo.dart';

--- a/lib/src/telegram/model.g.dart
+++ b/lib/src/telegram/model.g.dart
@@ -1031,17 +1031,18 @@ ChatMember _$ChatMemberFromJson(Map<String, dynamic> json) {
     status: json['status'] as String,
     until_date: json['until_date'] as int,
     can_be_edited: json['can_be_edited'] as bool,
-    can_change_info: json['can_change_info'] as bool,
     can_post_messages: json['can_post_messages'] as bool,
     can_edit_messages: json['can_edit_messages'] as bool,
     can_delete_messages: json['can_delete_messages'] as bool,
-    can_invite_users: json['can_invite_users'] as bool,
     can_restrict_members: json['can_restrict_members'] as bool,
-    can_pin_messages: json['can_pin_messages'] as bool,
     can_promote_members: json['can_promote_members'] as bool,
+    can_change_info: json['can_change_info'] as bool,
+    can_invite_users: json['can_invite_users'] as bool,
+    can_pin_messages: json['can_pin_messages'] as bool,
     is_member: json['is_member'] as bool,
     can_send_messages: json['can_send_messages'] as bool,
     can_send_media_messages: json['can_send_media_messages'] as bool,
+    can_send_polls: json['can_send_polls'] as bool,
     can_send_other_messages: json['can_send_other_messages'] as bool,
     can_add_web_page_previews: json['can_add_web_page_previews'] as bool,
   );
@@ -1060,17 +1061,18 @@ Map<String, dynamic> _$ChatMemberToJson(ChatMember instance) {
   writeNotNull('status', instance.status);
   writeNotNull('until_date', instance.until_date);
   writeNotNull('can_be_edited', instance.can_be_edited);
-  writeNotNull('can_change_info', instance.can_change_info);
   writeNotNull('can_post_messages', instance.can_post_messages);
   writeNotNull('can_edit_messages', instance.can_edit_messages);
   writeNotNull('can_delete_messages', instance.can_delete_messages);
-  writeNotNull('can_invite_users', instance.can_invite_users);
   writeNotNull('can_restrict_members', instance.can_restrict_members);
-  writeNotNull('can_pin_messages', instance.can_pin_messages);
   writeNotNull('can_promote_members', instance.can_promote_members);
+  writeNotNull('can_change_info', instance.can_change_info);
+  writeNotNull('can_invite_users', instance.can_invite_users);
+  writeNotNull('can_pin_messages', instance.can_pin_messages);
   writeNotNull('is_member', instance.is_member);
   writeNotNull('can_send_messages', instance.can_send_messages);
   writeNotNull('can_send_media_messages', instance.can_send_media_messages);
+  writeNotNull('can_send_polls', instance.can_send_polls);
   writeNotNull('can_send_other_messages', instance.can_send_other_messages);
   writeNotNull('can_add_web_page_previews', instance.can_add_web_page_previews);
   return val;

--- a/lib/src/telegram/model.g.dart
+++ b/lib/src/telegram/model.g.dart
@@ -148,6 +148,9 @@ Chat _$ChatFromJson(Map<String, dynamic> json) {
     pinned_message: json['pinned_message'] == null
         ? null
         : Message.fromJson(json['pinned_message'] as Map<String, dynamic>),
+    permissions: json['permissions'] == null
+        ? null
+        : ChatPermissions.fromJson(json['permissions'] as Map<String, dynamic>),
     sticker_set_name: json['sticker_set_name'] as String,
     can_set_sticker_set: json['can_set_sticker_set'] as bool,
   );
@@ -174,6 +177,7 @@ Map<String, dynamic> _$ChatToJson(Chat instance) {
   writeNotNull('description', instance.description);
   writeNotNull('invite_link', instance.invite_link);
   writeNotNull('pinned_message', instance.pinned_message);
+  writeNotNull('permissions', instance.permissions);
   writeNotNull('sticker_set_name', instance.sticker_set_name);
   writeNotNull('can_set_sticker_set', instance.can_set_sticker_set);
   return val;
@@ -1072,6 +1076,39 @@ Map<String, dynamic> _$ChatMemberToJson(ChatMember instance) {
   return val;
 }
 
+ChatPermissions _$ChatPermissionsFromJson(Map<String, dynamic> json) {
+  return ChatPermissions(
+    can_send_messages: json['can_send_messages'] as bool,
+    can_send_media_messages: json['can_send_media_messages'] as bool,
+    can_send_polls: json['can_send_polls'] as bool,
+    can_send_other_messages: json['can_send_other_messages'] as bool,
+    can_add_web_page_previews: json['can_add_web_page_previews'] as bool,
+    can_change_info: json['can_change_info'] as bool,
+    can_invite_users: json['can_invite_users'] as bool,
+    can_pin_messages: json['can_pin_messages'] as bool,
+  );
+}
+
+Map<String, dynamic> _$ChatPermissionsToJson(ChatPermissions instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('can_send_messages', instance.can_send_messages);
+  writeNotNull('can_send_media_messages', instance.can_send_media_messages);
+  writeNotNull('can_send_polls', instance.can_send_polls);
+  writeNotNull('can_send_other_messages', instance.can_send_other_messages);
+  writeNotNull('can_add_web_page_previews', instance.can_add_web_page_previews);
+  writeNotNull('can_change_info', instance.can_change_info);
+  writeNotNull('can_invite_users', instance.can_invite_users);
+  writeNotNull('can_pin_messages', instance.can_pin_messages);
+  return val;
+}
+
 ResponseParameters _$ResponseParametersFromJson(Map<String, dynamic> json) {
   return ResponseParameters(
     migrate_to_chat_id: json['migrate_to_chat_id'] as int,
@@ -1276,6 +1313,7 @@ Sticker _$StickerFromJson(Map<String, dynamic> json) {
     file_id: json['file_id'] as String,
     width: json['width'] as int,
     height: json['height'] as int,
+    is_animated: json['is_animated'] as bool,
     thumb: json['thumb'] == null
         ? null
         : PhotoSize.fromJson(json['thumb'] as Map<String, dynamic>),
@@ -1300,6 +1338,7 @@ Map<String, dynamic> _$StickerToJson(Sticker instance) {
   writeNotNull('file_id', instance.file_id);
   writeNotNull('width', instance.width);
   writeNotNull('height', instance.height);
+  writeNotNull('is_animated', instance.is_animated);
   writeNotNull('thumb', instance.thumb);
   writeNotNull('emoji', instance.emoji);
   writeNotNull('set_name', instance.set_name);
@@ -1312,6 +1351,7 @@ StickerSet _$StickerSetFromJson(Map<String, dynamic> json) {
   return StickerSet(
     name: json['name'] as String,
     title: json['title'] as String,
+    is_animated: json['is_animated'] as bool,
     contains_masks: json['contains_masks'] as bool,
     stickers: (json['stickers'] as List)
         ?.map((e) =>
@@ -1331,6 +1371,7 @@ Map<String, dynamic> _$StickerSetToJson(StickerSet instance) {
 
   writeNotNull('name', instance.name);
   writeNotNull('title', instance.title);
+  writeNotNull('is_animated', instance.is_animated);
   writeNotNull('contains_masks', instance.contains_masks);
   writeNotNull('stickers', instance.stickers);
   return val;

--- a/lib/src/telegram/models/chat.dart
+++ b/lib/src/telegram/models/chat.dart
@@ -21,6 +21,10 @@ part of '../model.dart';
 /// This object represents a chat.
 ///
 /// https://core.telegram.org/bots/api#chat
+///
+/// The field `all_members_are_administrators` is deprecated.
+/// The field is still returned in the object for backward compatibility, but new bots should use the `permissions` field instead.
+/// See: https://core.telegram.org/bots/api#july-29-2019
 @JsonSerializable()
 class Chat {
   int id;
@@ -34,6 +38,7 @@ class Chat {
   String description;
   String invite_link;
   Message pinned_message;
+  ChatPermissions permissions;
   String sticker_set_name;
   bool can_set_sticker_set;
   Chat(
@@ -48,6 +53,7 @@ class Chat {
       this.description,
       this.invite_link,
       this.pinned_message,
+      this.permissions,
       this.sticker_set_name,
       this.can_set_sticker_set});
   factory Chat.fromJson(Map<String, dynamic> json) => _$ChatFromJson(json);

--- a/lib/src/telegram/models/chat_member.dart
+++ b/lib/src/telegram/models/chat_member.dart
@@ -27,17 +27,18 @@ class ChatMember {
   String status;
   int until_date;
   bool can_be_edited;
-  bool can_change_info;
   bool can_post_messages;
   bool can_edit_messages;
   bool can_delete_messages;
-  bool can_invite_users;
   bool can_restrict_members;
-  bool can_pin_messages;
   bool can_promote_members;
+  bool can_change_info;
+  bool can_invite_users;
+  bool can_pin_messages;
   bool is_member;
   bool can_send_messages;
   bool can_send_media_messages;
+  bool can_send_polls;
   bool can_send_other_messages;
   bool can_add_web_page_previews;
   ChatMember(
@@ -45,17 +46,18 @@ class ChatMember {
       this.status,
       this.until_date,
       this.can_be_edited,
-      this.can_change_info,
       this.can_post_messages,
       this.can_edit_messages,
       this.can_delete_messages,
-      this.can_invite_users,
       this.can_restrict_members,
-      this.can_pin_messages,
       this.can_promote_members,
+      this.can_change_info,
+      this.can_invite_users,
+      this.can_pin_messages,
       this.is_member,
       this.can_send_messages,
       this.can_send_media_messages,
+      this.can_send_polls,
       this.can_send_other_messages,
       this.can_add_web_page_previews});
   factory ChatMember.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/telegram/models/chat_permissions.dart
+++ b/lib/src/telegram/models/chat_permissions.dart
@@ -1,0 +1,47 @@
+/**
+ * TeleDart - Telegram Bot API for Dart
+ * Copyright (C) 2019  Dino PH Leung
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+part of '../model.dart';
+
+/// Describes actions that a non-administrator user is allowed to take in a chat.
+///
+/// https://core.telegram.org/bots/api#chatpermissions
+@JsonSerializable()
+class ChatPermissions {
+  bool can_send_messages;
+  bool can_send_media_messages;
+  bool can_send_polls;
+  bool can_send_other_messages;
+  bool can_add_web_page_previews;
+  bool can_change_info;
+  bool can_invite_users;
+  bool can_pin_messages;
+  ChatPermissions(
+      {this.can_send_messages,
+      this.can_send_media_messages,
+      this.can_send_polls,
+      this.can_send_other_messages,
+      this.can_add_web_page_previews,
+      this.can_change_info,
+      this.can_invite_users,
+      this.can_pin_messages});
+  factory ChatPermissions.fromJson(Map<String, dynamic> json) =>
+      _$ChatPermissionsFromJson(json);
+  Map<String, dynamic> toJson(Map<String, dynamic> json) =>
+      _$ChatPermissionsToJson(this);
+}

--- a/lib/src/telegram/models/login_url.dart
+++ b/lib/src/telegram/models/login_url.dart
@@ -18,9 +18,14 @@
 
 part of '../model.dart';
 
-/// This object represents a point on the map.
+/// This object represents a parameter of the inline keyboard button used to automatically authorize a user.
+/// Serves as a great replacement for the [Telegram Login Widget] when the user is coming from Telegram.
+/// All the user needs to do is tap/click a button and confirm that they want to log in.
 ///
-/// https://core.telegram.org/bots/api#location
+/// Telegram apps support these buttons as of [version 5.7].
+///
+/// [Telegram Login Widget]: https://core.telegram.org/widgets/login
+/// [version 5.7]: https://telegram.org/blog/privacy-discussions-web-bots#meet-seamless-web-bots
 @JsonSerializable()
 class LoginUrl {
   String url;

--- a/lib/src/telegram/models/login_url.dart
+++ b/lib/src/telegram/models/login_url.dart
@@ -24,6 +24,8 @@ part of '../model.dart';
 ///
 /// Telegram apps support these buttons as of [version 5.7].
 ///
+/// https://core.telegram.org/bots/api#loginurl
+///
 /// [Telegram Login Widget]: https://core.telegram.org/widgets/login
 /// [version 5.7]: https://telegram.org/blog/privacy-discussions-web-bots#meet-seamless-web-bots
 @JsonSerializable()

--- a/lib/src/telegram/models/sticker.dart
+++ b/lib/src/telegram/models/sticker.dart
@@ -26,6 +26,7 @@ class Sticker {
   String file_id;
   int width;
   int height;
+  bool is_animated;
   PhotoSize thumb;
   String emoji;
   String set_name;
@@ -35,6 +36,7 @@ class Sticker {
       {this.file_id,
       this.width,
       this.height,
+      this.is_animated,
       this.thumb,
       this.emoji,
       this.set_name,

--- a/lib/src/telegram/models/sticker_set.dart
+++ b/lib/src/telegram/models/sticker_set.dart
@@ -25,9 +25,15 @@ part of '../model.dart';
 class StickerSet {
   String name;
   String title;
+  bool is_animated;
   bool contains_masks;
   List<Sticker> stickers;
-  StickerSet({this.name, this.title, this.contains_masks, this.stickers});
+  StickerSet(
+      {this.name,
+      this.title,
+      this.is_animated,
+      this.contains_masks,
+      this.stickers});
   factory StickerSet.fromJson(Map<String, dynamic> json) =>
       _$StickerSetFromJson(json);
   Map<String, dynamic> toJson() => _$StickerSetToJson(this);

--- a/lib/src/telegram/telegram.dart
+++ b/lib/src/telegram/telegram.dart
@@ -986,6 +986,19 @@ class Telegram {
     return await _client.httpPost(requestUrl, body: body);
   }
 
+  /// Use this method to set default chat permissions for all members.
+  /// The bot must be an administrator in the group or a supergroup for this to work and must have the can_restrict_members admin rights.
+  /// Returns *True* on success.
+  Future<bool> setChatPermissions(
+      int chat_id, ChatPermissions permissions) async {
+    String requestUrl = '${_baseUrl}${_token}/setChatPermissions';
+    Map<String, dynamic> body = {
+      'chat_id': chat_id,
+      'permissions': jsonEncode(permissions)
+    };
+    return _client.httpPost(requestUrl, body: body);
+  }
+
   /// Use this method to generate a invite link for a chat;
   /// any previously generated link is revoked.
   /// The bot must be an administrator in the chat for this to work and must have the appropriate

--- a/lib/src/telegram/telegram.dart
+++ b/lib/src/telegram/telegram.dart
@@ -936,8 +936,12 @@ class Telegram {
   /// Returns *True* on success.
   ///
   /// https://core.telegram.org/bots/api#restrictchatmember
+  ///
+  /// This method now takes the new user permissions in a single argument of the type *ChatPermissions*.
+  /// The old way of passing parameters will keep working for a while for backward compatibility.
   Future<bool> restrictChatMember(int chat_id, int user_id,
-      {int until_date,
+      {ChatPermissions permissions,
+      int until_date,
       bool can_send_messages,
       bool can_send_media_messages,
       bool can_send_other_messages,
@@ -946,6 +950,7 @@ class Telegram {
     Map<String, dynamic> body = {
       'chat_id': chat_id,
       'user_id': user_id,
+      'permissions': permissions == null ? '' : jsonEncode(permissions),
       'until_date': until_date ?? '',
       'can_send_messages': can_send_messages ?? '',
       'can_send_media_messages': can_send_media_messages ?? '',


### PR DESCRIPTION
Fixes #74 

- [x] New field is_animated in Sticker and StickerSet objects, animated stickers can now be used in sendSticker and InlineQueryResultCachedSticker
- [x] New object ChatPermissions, containing actions which a member can take in a chat. New field permissions in the Chat object; new method setChatPermissions.
- [x] The field all_members_are_administrators has been removed from the documentation for the Chat object. The field is still returned in the object for backward compatibility, but new bots should use the permissions field instead.
- [x] added the new field can_send_polls to ChatMember object, added can_change_info, can_invite_users, can_pin_messages in ChatMember object for restricted users
- [x] The method restrictChatMember now takes the new user permissions in a single argument of the type ChatPermissions. The old way of passing parameters will keep working for a while for backward compatibility.
- [x] Added description support for basic groups (previously available in supergroups and channel chats). You can pass a group's chat_id to setChatDescription and receive the group's description in the Chat object in the response to getChat method. (No actions required)
- [x] Added invite_link support for basic groups (previously available in supergroups and channel chats). You can pass a group's chat_id to exportChatInviteLink and receive the group's invite link in the Chat object in the response to getChat method. (No actions required)
- [x] File identifiers from the ChatPhoto object are now invalidated and can no longer be used whenever the photo is changed. (No actions required)
- [x] As of the next Bot API update (version 4.5), nested MessageEntity objects will be allowed in message texts and captions. Please make sure that your code can correctly handle such entities. (Already supported 😈 )