### PR TITLE
Fix removeLongPolling to actually stop polling

### DIFF
--- a/lib/src/teledart/teledart.dart
+++ b/lib/src/teledart/teledart.dart
@@ -89,7 +89,10 @@ class TeleDart {
 
   /// Removes and stops long polling
   void removeLongPolling() {
-    if (_longPolling != null) _longPolling = null;
+    if (_longPolling != null) {
+      _longPolling.stopPolling();
+      _longPolling = null;
+    }
   }
 
   /// Configures webhook method


### PR DESCRIPTION
The removeLongPolling method only set _longPolling variable to null but the recursive polling continued to action.

This fix also add call to stopPolling() that sets internal variable to false and recursive GET polling request is stopped.