### PR TITLE
Add check to make sure command is valid

### DIFF
--- a/lib/src/teledart/event/event.dart
+++ b/lib/src/teledart/event/event.dart
@@ -93,7 +93,8 @@ class Event {
                     : '';
                 break;
               case 'bot_command': //'\/${keyword}' or '\/${keyword}\@${me.username}'
-                entityText = message.getEntity(entityType).isNotEmpty
+                entityText = message.getEntity(entityType).isNotEmpty &&
+                        message.entities[0].offset == 0
                     ? message
                         .getEntity(entityType)
                         .substring(1)


### PR DESCRIPTION
Commands should always be in the beginning of the message. By making sure the offset of the entity is 0, only valid commands will pass through.
For example, '/start' is valid but 'Telegram is cool /start' isn't.