### PR TITLE
Added getter for _token

### DIFF
--- a/lib/src/telegram/telegram.dart
+++ b/lib/src/telegram/telegram.dart
@@ -27,6 +27,8 @@ class Telegram {
   final String _baseUrl = 'https://api.telegram.org/bot';
   final String _token;
 
+  String get token => _token;
+
   Telegram(this._token);
 
   /// Use this method to receive incoming updates using long polling ([wiki]).


### PR DESCRIPTION
Token is completely inaccessible now, but we need it's value in some situations like file downloading. According to documentation https://core.telegram.org/bots/api#file all files are accessible via URL https://api.telegram.org/file/bot<token>/<file_path>. Whereas "file_path" we can get using getFile, "token" is protected, so we should do any tricks to store it in another place than teledart's API. Or Subclass the Telegram to reimplement constructor and create own copy of the token. And this looks like dirty hack too...