### PR TITLE
Fixed 429 http status error

### DIFF
--- a/lib/src/teledart/fetch/long_polling.dart
+++ b/lib/src/teledart/fetch/long_polling.dart
@@ -107,11 +107,16 @@ class LongPolling extends AbstractUpdateFetcher {
     return Future.value();
   }
 
-  void _onRecursivePollingHttpError(HttpClientException error) {
-    if (error.isHttpClientError()) {
+  void _onRecursivePollingHttpError(HttpClientException error) async {
+    if (error.code != 429 && error.isHttpClientError()) {
       _isPolling = false;
       throw LongPollingException(error.toString());
     } else {
+      // Too many requests (awaiting 5 seconds)
+      if (error.code == 429) {
+        await Future.delayed(const Duration(seconds: 5));
+      }
+
       _onRecursivePollingError(error);
     }
   }

--- a/lib/src/teledart/fetch/long_polling.dart
+++ b/lib/src/teledart/fetch/long_polling.dart
@@ -107,7 +107,7 @@ class LongPolling extends AbstractUpdateFetcher {
     return Future.value();
   }
 
-  void _onRecursivePollingHttpError(HttpClientException error) async {
+  Future<void> _onRecursivePollingHttpError(HttpClientException error) async {
     if (error.code != 429 && error.isHttpClientError()) {
       _isPolling = false;
       throw LongPollingException(error.toString());


### PR DESCRIPTION
When Telegram sends 429 HTTP status code on long polling: awaiting for 5 seconds before re-execute recursive polling.

The trace of this error begins in LongPolling.start async method, which is executed by TeleDart.start sync method, which means final users cannot catch this error by wrapping TeleDart.start in a try/catch block.

This solution provides a way to prevent a whole App that uses this library crashes when Telegram server sends 429 HTTP status code. 