### PR TITLE
Fixed 429 http status error

### DIFF
--- a/lib/src/teledart/fetch/long_polling.dart
+++ b/lib/src/teledart/fetch/long_polling.dart
@@ -107,11 +107,16 @@ class LongPolling extends AbstractUpdateFetcher {
     return Future.value();
   }
 
-  void _onRecursivePollingHttpError(HttpClientException error) {
-    if (error.isHttpClientError()) {
+  void _onRecursivePollingHttpError(HttpClientException error) async {
+    if (error.code != 429 && error.isHttpClientError()) {
       _isPolling = false;
       throw LongPollingException(error.toString());
     } else {
+      // Too many requests (awaiting 5 seconds)
+      if (error.code == 429) {
+        await Future.delayed(const Duration(seconds: 5));
+      }
+
       _onRecursivePollingError(error);
     }
   }

--- a/lib/src/teledart/fetch/long_polling.dart
+++ b/lib/src/teledart/fetch/long_polling.dart
@@ -107,7 +107,7 @@ class LongPolling extends AbstractUpdateFetcher {
     return Future.value();
   }
 
-  void _onRecursivePollingHttpError(HttpClientException error) async {
+  Future<void> _onRecursivePollingHttpError(HttpClientException error) async {
     if (error.code != 429 && error.isHttpClientError()) {
       _isPolling = false;
       throw LongPollingException(error.toString());

--- a/lib/src/util/http_client.dart
+++ b/lib/src/util/http_client.dart
@@ -38,8 +38,8 @@ class HttpClient {
         if (responseBody['ok']) {
           return responseBody['result'];
         } else {
-          return Future.error(HttpClientException(
-              responseBody['error_code'], responseBody['description']));
+          return Future.error(HttpClientException(responseBody['error_code'],
+              responseBody['description'], response.headers));
         }
       }).catchError((error) => Future.error(error));
 
@@ -55,8 +55,8 @@ class HttpClient {
       if (responseBody['ok']) {
         return responseBody['result'];
       } else {
-        return Future.error(HttpClientException(
-            responseBody['error_code'], responseBody['description']));
+        return Future.error(HttpClientException(responseBody['error_code'],
+            responseBody['description'], response.headers));
       }
     }).catchError((error) => Future.error(error));
   }
@@ -81,8 +81,8 @@ class HttpClient {
       if (responseBody['ok']) {
         return responseBody['result'];
       } else {
-        return Future.error(HttpClientException(
-            responseBody['error_code'], responseBody['description']));
+        return Future.error(HttpClientException(responseBody['error_code'],
+            responseBody['description'], response.headers));
       }
     }).catchError((error) => Future.error(error));
   }
@@ -91,7 +91,8 @@ class HttpClient {
 class HttpClientException implements Exception {
   int code;
   String description;
-  HttpClientException(this.code, this.description);
+  Map<String, String> headers;
+  HttpClientException(this.code, this.description, this.headers);
   bool isHttpClientError() => code >= 400 && code < 500;
   @override
   String toString() => 'HttpClientException: $code $description';


### PR DESCRIPTION
When Telegram sends 429 HTTP status code on long polling: awaiting for `retry_after` header value or 2500 milliseconds before re-execute recursive polling.

The trace of this error begins in LongPolling.start async method, which is executed by TeleDart.start sync method, which means final users cannot catch this error by wrapping TeleDart.start in a try/catch block.

This solution provides a way to prevent a whole App that uses this library crashes when Telegram server sends 429 HTTP status code.
